### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libviprs-bench"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2024"
 authors = ["Roman Goldmann <roman@devshell.org>"]
 rust-version = "1.85"

--- a/benches/engine_comparison.rs
+++ b/benches/engine_comparison.rs
@@ -72,6 +72,7 @@ fn bench_streaming_engine(c: &mut Criterion) {
                     let config = StreamingConfig {
                         memory_budget_bytes: STREAMING_BUDGET,
                         engine: EngineConfig::default(),
+                        budget_policy: libviprs::streaming::BudgetPolicy::Error,
                     };
                     let strip_src = RasterStripSource::new(&src);
                     generate_pyramid_streaming(
@@ -95,6 +96,7 @@ fn bench_streaming_engine(c: &mut Criterion) {
                     let config = StreamingConfig {
                         memory_budget_bytes: STREAMING_BUDGET,
                         engine: EngineConfig::default().with_concurrency(4),
+                        budget_policy: libviprs::streaming::BudgetPolicy::Error,
                     };
                     let strip_src = RasterStripSource::new(&src);
                     generate_pyramid_streaming(
@@ -203,6 +205,7 @@ fn bench_head_to_head(c: &mut Criterion) {
                     let config = StreamingConfig {
                         memory_budget_bytes: STREAMING_BUDGET,
                         engine: EngineConfig::default(),
+                        budget_policy: libviprs::streaming::BudgetPolicy::Error,
                     };
                     let strip_src = RasterStripSource::new(&src);
                     generate_pyramid_streaming(

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -153,6 +153,7 @@ fn main() {
         let config = StreamingConfig {
             memory_budget_bytes: 1_000_000,
             engine: EngineConfig::default(),
+            budget_policy: libviprs::streaming::BudgetPolicy::Error,
         };
 
         let strip_src = RasterStripSource::new(&src);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,7 @@ pub fn bench_streaming(
     let config = StreamingConfig {
         memory_budget_bytes,
         engine: EngineConfig::default().with_concurrency(concurrency),
+        budget_policy: libviprs::streaming::BudgetPolicy::Error,
     };
 
     let strip_src = RasterStripSource::new(src);
@@ -243,7 +244,7 @@ pub fn bench_mapreduce(
         .iter()
         .filter(|e| matches!(e, EngineEvent::BatchStarted { .. }))
         .count() as u32;
-    let inflight = libviprs::compute_inflight_strips(
+    let inflight = libviprs::streaming_mapreduce::compute_inflight_strips(
         plan,
         src.format(),
         libviprs::compute_strip_height(plan, src.format(), memory_budget_bytes)

--- a/src/scalability.rs
+++ b/src/scalability.rs
@@ -59,6 +59,7 @@ fn run_streaming(src: &Raster, tile_size: u32, budget: u64) -> (std::time::Durat
     let config = StreamingConfig {
         memory_budget_bytes: budget,
         engine: EngineConfig::default(),
+        budget_policy: libviprs::streaming::BudgetPolicy::Error,
     };
     let strip_src = RasterStripSource::new(src);
     let start = Instant::now();


### PR DESCRIPTION
Bumps libviprs-bench to 0.2.0 alongside the libviprs 0.2.0 release.

## Test plan
- [ ] CI green