### PR TITLE
docs: add README with CLI doc cross-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Benchmark harness for [libviprs](../libviprs), comparing its three pyramid engin
 
 This crate is kept in a separate repository so the library crate stays free of heavy benchmark-only dependencies (criterion, plotters, libvips FFI).
 
+> Flag reference and runnable Rust examples for every knob the benchmarks
+> tune live at <https://libviprs.org/cli/>.
+
 ## What this is
 
 `libviprs-bench` measures how libviprs scales as image size and concurrency change, and how it compares to libvips on the same workload. Both libraries are linked into a single process so neither side gets a filesystem-I/O advantage.
@@ -78,6 +81,66 @@ cargo run --release --bin flamegraph
 # writes report/flamegraph_{monolithic,streaming,mapreduce}.svg
 ```
 
+## Benchmark scenarios and the flags they exercise
+
+Each scenario tunes a knob the [libviprs CLI](https://libviprs.org/cli/)
+also exposes. The links below jump straight to the flag picker entry — it
+includes a description, defaults, and a runnable Rust snippet.
+
+### Scalability sweep (`src/scalability.rs`)
+
+Sweeps a gradient raster from 512x360 to 8192x5760 and runs all four
+engines at each size. Three knobs are pinned per run:
+
+- **Streaming budget** — `STREAMING_BUDGET = 4_000_000` bytes is fed to
+  both the streaming and MapReduce engines, forcing strip-bounded
+  behaviour. Equivalent CLI flag:
+  [`--memory-budget`](https://libviprs.org/cli/#flag-memory-budget).
+- **MapReduce in-flight strips** — `tile_concurrency = 4`. Equivalent CLI
+  flag: [`--concurrency`](https://libviprs.org/cli/#flag-concurrency).
+- **Tile size** — `TILE_SIZE = 256`. The CLI exposes the same
+  [pyramid](https://libviprs.org/cli/#pyramid) layout/tile knobs.
+
+The Docker memory cap on `run-bench.sh --memory <MB>` corresponds to the
+process-level [`--memory-limit`](https://libviprs.org/cli/#flag-memory-limit)
+in the CLI: the engine's own
+[`--memory-budget`](https://libviprs.org/cli/#flag-memory-budget) must be
+chosen to fit beneath it.
+
+### Criterion micro-benchmarks (`benches/engine_comparison.rs`)
+
+Four benchmark groups, each parameterised on image size:
+
+- `monolithic` — single-thread vs `EngineConfig::default().with_concurrency(4)`.
+  See [`--parallel`](https://libviprs.org/cli/#flag-parallel) /
+  [`--concurrency`](https://libviprs.org/cli/#flag-concurrency).
+- `streaming` — single-thread vs 4-thread, both at 1 MB
+  [`--memory-budget`](https://libviprs.org/cli/#flag-memory-budget).
+- `mapreduce` — `tile_concurrency = 0` vs `4`, exercising
+  [`--concurrency`](https://libviprs.org/cli/#flag-concurrency) under the
+  same 1 MB budget.
+- `head_to_head` — monolithic, streaming, mapreduce, and `mapreduce_4t` at
+  matched sizes, isolating the
+  [`--memory-budget`](https://libviprs.org/cli/#flag-memory-budget) /
+  [`--concurrency`](https://libviprs.org/cli/#flag-concurrency) tradeoff.
+
+### `pdf_engine_bench` (`src/pdf_engine_bench.rs`)
+
+Renders one PDF page through one engine and writes a JSON report. The CLI
+flags it accepts mirror the libviprs CLI:
+
+| `pdf_engine_bench` flag | CLI equivalent                                              |
+|-------------------------|-------------------------------------------------------------|
+| `--engine mono\|stream` | engine selection (see CLI flag picker)                      |
+| `--budget-bytes`        | [`--memory-budget`](https://libviprs.org/cli/#flag-memory-budget) |
+| `--tile-size`           | [pyramid layout](https://libviprs.org/cli/#pyramid)         |
+| `--dpi`, `--page`, `--layout` | matched 1:1 in the CLI                                |
+
+Streaming runs additionally honour an internal strip-buffer sizing knob
+analogous to [`--buffer-size`](https://libviprs.org/cli/#flag-buffer-size);
+the bench fixes it via `compute_strip_height` against the budget so the
+two engines see byte-identical input dimensions.
+
 ## Docker
 
 `run-bench.sh` builds a Docker image with libvips, PDFium, and both crates side-by-side, then runs the chosen binary inside it with a memory limit. This is the recommended path because it pins the libvips version and isolates the host from the benchmark.
@@ -136,6 +199,22 @@ report/
 - Rust 1.85+ (edition 2024)
 - Docker (recommended, used by `run-bench.sh`)
 - For `--no-build`: `libvips-dev` and `pkg-config` on the host
+
+## See also
+
+- [libviprs CLI flag reference](https://libviprs.org/cli/) — every knob
+  the benchmarks tune, with defaults and runnable Rust examples.
+- [`#pyramid`](https://libviprs.org/cli/#pyramid) — tile size, layout,
+  level count.
+- [`#flag-memory-budget`](https://libviprs.org/cli/#flag-memory-budget) —
+  engine-level budget driving strip height.
+- [`#flag-memory-limit`](https://libviprs.org/cli/#flag-memory-limit) —
+  process-level cap; what `run-bench.sh --memory` enforces via Docker.
+- [`#flag-parallel`](https://libviprs.org/cli/#flag-parallel) /
+  [`#flag-concurrency`](https://libviprs.org/cli/#flag-concurrency) —
+  thread-count knobs measured by the Criterion groups.
+- [`#flag-buffer-size`](https://libviprs.org/cli/#flag-buffer-size) —
+  streaming strip buffer.
 
 ## Related Crates
 


### PR DESCRIPTION
## Summary

- Adds the repo's first README.md with a top-of-file pointer to https://libviprs.org/cli/ and per-scenario links into anchors like `#flag-memory-budget`, `#flag-parallel`, `#flag-concurrency`, `#flag-buffer-size`.
- Existing benchmark code, numbers, and Criterion configs are unchanged.

## Test plan

- [ ] Render the README on GitHub and click a few of the cli/#flag-... anchors.