### PR TITLE
feat(scalability): default x-axis crop + --no-crop / --replot flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [features]
 default = []
 libvips = ["dep:libvips-rs"]
+pdfium = ["libviprs/pdfium"]
 
 [dependencies]
 libviprs = { path = "../libviprs" }
@@ -40,3 +41,8 @@ path = "src/report.rs"
 [[bin]]
 name = "scalability"
 path = "src/scalability.rs"
+
+[[bin]]
+name = "pdfium_strip_source_bench"
+path = "src/pdfium_strip_source_bench.rs"
+required-features = ["pdfium"]

--- a/benches/engine_comparison.rs
+++ b/benches/engine_comparison.rs
@@ -75,14 +75,8 @@ fn bench_streaming_engine(c: &mut Criterion) {
                         budget_policy: libviprs::streaming::BudgetPolicy::Error,
                     };
                     let strip_src = RasterStripSource::new(&src);
-                    generate_pyramid_streaming(
-                        &strip_src,
-                        &plan,
-                        &sink,
-                        &config,
-                        &NoopObserver,
-                    )
-                    .unwrap();
+                    generate_pyramid_streaming(&strip_src, &plan, &sink, &config, &NoopObserver)
+                        .unwrap();
                 });
             },
         );
@@ -99,14 +93,8 @@ fn bench_streaming_engine(c: &mut Criterion) {
                         budget_policy: libviprs::streaming::BudgetPolicy::Error,
                     };
                     let strip_src = RasterStripSource::new(&src);
-                    generate_pyramid_streaming(
-                        &strip_src,
-                        &plan,
-                        &sink,
-                        &config,
-                        &NoopObserver,
-                    )
-                    .unwrap();
+                    generate_pyramid_streaming(&strip_src, &plan, &sink, &config, &NoopObserver)
+                        .unwrap();
                 });
             },
         );
@@ -136,14 +124,8 @@ fn bench_mapreduce_engine(c: &mut Criterion) {
                         ..MapReduceConfig::default()
                     };
                     let strip_src = RasterStripSource::new(&src);
-                    generate_pyramid_mapreduce(
-                        &strip_src,
-                        &plan,
-                        &sink,
-                        &config,
-                        &NoopObserver,
-                    )
-                    .unwrap();
+                    generate_pyramid_mapreduce(&strip_src, &plan, &sink, &config, &NoopObserver)
+                        .unwrap();
                 });
             },
         );
@@ -160,14 +142,8 @@ fn bench_mapreduce_engine(c: &mut Criterion) {
                         ..MapReduceConfig::default()
                     };
                     let strip_src = RasterStripSource::new(&src);
-                    generate_pyramid_mapreduce(
-                        &strip_src,
-                        &plan,
-                        &sink,
-                        &config,
-                        &NoopObserver,
-                    )
-                    .unwrap();
+                    generate_pyramid_mapreduce(&strip_src, &plan, &sink, &config, &NoopObserver)
+                        .unwrap();
                 });
             },
         );
@@ -208,14 +184,8 @@ fn bench_head_to_head(c: &mut Criterion) {
                         budget_policy: libviprs::streaming::BudgetPolicy::Error,
                     };
                     let strip_src = RasterStripSource::new(&src);
-                    generate_pyramid_streaming(
-                        &strip_src,
-                        &plan,
-                        &sink,
-                        &config,
-                        &NoopObserver,
-                    )
-                    .unwrap();
+                    generate_pyramid_streaming(&strip_src, &plan, &sink, &config, &NoopObserver)
+                        .unwrap();
                 });
             },
         );
@@ -232,14 +202,8 @@ fn bench_head_to_head(c: &mut Criterion) {
                         ..MapReduceConfig::default()
                     };
                     let strip_src = RasterStripSource::new(&src);
-                    generate_pyramid_mapreduce(
-                        &strip_src,
-                        &plan,
-                        &sink,
-                        &config,
-                        &NoopObserver,
-                    )
-                    .unwrap();
+                    generate_pyramid_mapreduce(&strip_src, &plan, &sink, &config, &NoopObserver)
+                        .unwrap();
                 });
             },
         );
@@ -256,14 +220,8 @@ fn bench_head_to_head(c: &mut Criterion) {
                         ..MapReduceConfig::default()
                     };
                     let strip_src = RasterStripSource::new(&src);
-                    generate_pyramid_mapreduce(
-                        &strip_src,
-                        &plan,
-                        &sink,
-                        &config,
-                        &NoopObserver,
-                    )
-                    .unwrap();
+                    generate_pyramid_mapreduce(&strip_src, &plan, &sink, &config, &NoopObserver)
+                        .unwrap();
                 });
             },
         );

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -15,12 +15,13 @@ use std::path::Path;
 use std::time::Instant;
 
 use inferno::flamegraph::{self, Options};
+use libviprs::streaming::BudgetPolicy;
 use libviprs::{
-    CollectingObserver, EngineConfig, EngineEvent, Layout, MapReduceConfig, MemorySink,
-    PyramidPlanner, RasterStripSource, StreamingConfig, generate_pyramid_mapreduce,
-    generate_pyramid_observed, generate_pyramid_streaming,
+    CollectingObserver, EngineBuilder, EngineConfig, EngineEvent, EngineKind, Layout, MemorySink,
+    PyramidPlanner, RasterStripSource,
 };
 use libviprs_bench::gradient_raster;
+use std::sync::Arc;
 
 const WIDTH: u32 = 4096;
 const HEIGHT: u32 = 4096;
@@ -38,12 +39,12 @@ fn events_to_folded_stacks(events: &[EngineEvent], engine_name: &str) -> Vec<Str
 
     for event in events {
         match event {
-            EngineEvent::LevelStarted { level, tile_count, .. } => {
+            EngineEvent::LevelStarted {
+                level, tile_count, ..
+            } => {
                 current_level = Some(*level);
                 _level_tiles = 0;
-                stacks.push(format!(
-                    "{engine_name};level_{level}_start {tile_count}"
-                ));
+                stacks.push(format!("{engine_name};level_{level}_start {tile_count}"));
             }
             EngineEvent::TileCompleted { coord } => {
                 _level_tiles += 1;
@@ -54,27 +55,43 @@ fn events_to_folded_stacks(events: &[EngineEvent], engine_name: &str) -> Vec<Str
                     ));
                 }
             }
-            EngineEvent::LevelCompleted { level, tiles_produced } => {
+            EngineEvent::LevelCompleted {
+                level,
+                tiles_produced,
+            } => {
                 stacks.push(format!(
                     "{engine_name};level_{level}_complete {tiles_produced}"
                 ));
             }
-            EngineEvent::StripRendered { strip_index, total_strips } => {
+            EngineEvent::StripRendered {
+                strip_index,
+                total_strips,
+            } => {
                 stacks.push(format!(
                     "{engine_name};strip_{strip_index}_of_{total_strips} 1"
                 ));
             }
-            EngineEvent::BatchStarted { batch_index, strips_in_batch, .. } => {
+            EngineEvent::BatchStarted {
+                batch_index,
+                strips_in_batch,
+                ..
+            } => {
                 stacks.push(format!(
                     "{engine_name};batch_{batch_index}_{strips_in_batch}strips 1"
                 ));
             }
-            EngineEvent::BatchCompleted { batch_index, tiles_produced } => {
+            EngineEvent::BatchCompleted {
+                batch_index,
+                tiles_produced,
+            } => {
                 stacks.push(format!(
                     "{engine_name};batch_{batch_index}_done_{tiles_produced}tiles 1"
                 ));
             }
-            EngineEvent::Finished { total_tiles, levels } => {
+            EngineEvent::Finished {
+                total_tiles,
+                levels,
+            } => {
                 stacks.push(format!(
                     "{engine_name};finished_{levels}levels_{total_tiles}tiles 1"
                 ));
@@ -98,12 +115,7 @@ fn generate_flamegraph(stacks: &[String], output_path: &Path, title: &str) {
     let lines: Vec<&str> = stacks.iter().map(|s| s.as_str()).collect();
     let reader = lines.join("\n");
 
-    flamegraph::from_reader(
-        &mut opts,
-        reader.as_bytes(),
-        writer,
-    )
-    .expect("generate flamegraph");
+    flamegraph::from_reader(&mut opts, reader.as_bytes(), writer).expect("generate flamegraph");
 }
 
 fn main() {
@@ -111,8 +123,7 @@ fn main() {
     fs::create_dir_all(&report_dir).unwrap();
 
     let src = gradient_raster(WIDTH, HEIGHT);
-    let planner =
-        PyramidPlanner::new(WIDTH, HEIGHT, TILE_SIZE, 0, Layout::DeepZoom).unwrap();
+    let planner = PyramidPlanner::new(WIDTH, HEIGHT, TILE_SIZE, 0, Layout::DeepZoom).unwrap();
     let plan = planner.plan();
 
     println!("Image: {WIDTH}x{HEIGHT}, tile_size={TILE_SIZE}");
@@ -126,11 +137,15 @@ fn main() {
     // --- Monolithic ---
     {
         let sink = MemorySink::new();
-        let observer = CollectingObserver::new();
-        let config = EngineConfig::default();
+        let observer = Arc::new(CollectingObserver::new());
 
         let start = Instant::now();
-        let result = generate_pyramid_observed(&src, &plan, &sink, &config, &observer).unwrap();
+        let result = EngineBuilder::new(&src, plan.clone(), &sink)
+            .with_engine(EngineKind::Monolithic)
+            .with_config(EngineConfig::default())
+            .with_observer_arc(observer.clone())
+            .run()
+            .unwrap();
         let elapsed = start.elapsed();
 
         println!(
@@ -142,24 +157,29 @@ fn main() {
 
         let stacks = events_to_folded_stacks(&observer.events(), "monolithic");
         let path = report_dir.join("flamegraph_monolithic.svg");
-        generate_flamegraph(&stacks, &path, "libviprs monolithic engine — event flame graph");
+        generate_flamegraph(
+            &stacks,
+            &path,
+            "libviprs monolithic engine — event flame graph",
+        );
         println!("  → {}", path.display());
     }
 
     // --- Streaming ---
     {
         let sink = MemorySink::new();
-        let observer = CollectingObserver::new();
-        let config = StreamingConfig {
-            memory_budget_bytes: 1_000_000,
-            engine: EngineConfig::default(),
-            budget_policy: libviprs::streaming::BudgetPolicy::Error,
-        };
+        let observer = Arc::new(CollectingObserver::new());
 
         let strip_src = RasterStripSource::new(&src);
         let start = Instant::now();
-        let result =
-            generate_pyramid_streaming(&strip_src, &plan, &sink, &config, &observer).unwrap();
+        let result = EngineBuilder::new(strip_src, plan.clone(), &sink)
+            .with_engine(EngineKind::Streaming)
+            .with_config(EngineConfig::default())
+            .with_memory_budget(1_000_000)
+            .with_budget_policy(BudgetPolicy::Error)
+            .with_observer_arc(observer.clone())
+            .run()
+            .unwrap();
         let elapsed = start.elapsed();
 
         let strip_count = observer
@@ -178,24 +198,29 @@ fn main() {
 
         let stacks = events_to_folded_stacks(&observer.events(), "streaming");
         let path = report_dir.join("flamegraph_streaming.svg");
-        generate_flamegraph(&stacks, &path, "libviprs streaming engine — event flame graph");
+        generate_flamegraph(
+            &stacks,
+            &path,
+            "libviprs streaming engine — event flame graph",
+        );
         println!("  → {}", path.display());
     }
 
     // --- MapReduce ---
     {
         let sink = MemorySink::new();
-        let observer = CollectingObserver::new();
-        let config = MapReduceConfig {
-            memory_budget_bytes: 1_000_000,
-            tile_concurrency: 0,
-            ..MapReduceConfig::default()
-        };
+        let observer = Arc::new(CollectingObserver::new());
 
         let strip_src = RasterStripSource::new(&src);
         let start = Instant::now();
-        let result =
-            generate_pyramid_mapreduce(&strip_src, &plan, &sink, &config, &observer).unwrap();
+        let result = EngineBuilder::new(strip_src, plan.clone(), &sink)
+            .with_engine(EngineKind::MapReduce)
+            .with_config(EngineConfig::default().with_concurrency(0))
+            .with_memory_budget(1_000_000)
+            .with_budget_policy(BudgetPolicy::Error)
+            .with_observer_arc(observer.clone())
+            .run()
+            .unwrap();
         let elapsed = start.elapsed();
 
         let events = observer.events();
@@ -219,7 +244,11 @@ fn main() {
 
         let stacks = events_to_folded_stacks(&events, "mapreduce");
         let path = report_dir.join("flamegraph_mapreduce.svg");
-        generate_flamegraph(&stacks, &path, "libviprs MapReduce engine — event flame graph");
+        generate_flamegraph(
+            &stacks,
+            &path,
+            "libviprs MapReduce engine — event flame graph",
+        );
         println!("  → {}", path.display());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,13 @@
 //! profiling binaries.
 
 use std::process::Command;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use libviprs::streaming::BudgetPolicy;
 use libviprs::{
-    CollectingObserver, EngineConfig, EngineEvent, Layout, MapReduceConfig, MemorySink,
-    PixelFormat, PyramidPlan, PyramidPlanner, Raster, RasterStripSource, StreamingConfig,
-    generate_pyramid_mapreduce, generate_pyramid_observed, generate_pyramid_streaming,
+    CollectingObserver, EngineBuilder, EngineConfig, EngineEvent, EngineKind, Layout, MemorySink,
+    PixelFormat, PyramidPlan, PyramidPlanner, Raster, RasterStripSource,
 };
 use serde::{Deserialize, Serialize};
 
@@ -140,11 +141,16 @@ pub fn bench_monolithic(
     label: &str,
 ) -> RunMetrics {
     let sink = MemorySink::new();
-    let observer = CollectingObserver::new();
+    let observer = Arc::new(CollectingObserver::new());
     let config = EngineConfig::default().with_concurrency(concurrency);
 
     let start = Instant::now();
-    let result = generate_pyramid_observed(src, plan, &sink, &config, &observer).unwrap();
+    let result = EngineBuilder::new(src, plan.clone(), &sink)
+        .with_engine(EngineKind::Monolithic)
+        .with_config(config)
+        .with_observer_arc(observer.clone())
+        .run()
+        .unwrap();
     let wall_time = start.elapsed();
 
     RunMetrics {
@@ -174,17 +180,18 @@ pub fn bench_streaming(
     label: &str,
 ) -> RunMetrics {
     let sink = MemorySink::new();
-    let observer = CollectingObserver::new();
-    let config = StreamingConfig {
-        memory_budget_bytes,
-        engine: EngineConfig::default().with_concurrency(concurrency),
-        budget_policy: libviprs::streaming::BudgetPolicy::Error,
-    };
-
+    let observer = Arc::new(CollectingObserver::new());
+    let engine_config = EngineConfig::default().with_concurrency(concurrency);
     let strip_src = RasterStripSource::new(src);
     let start = Instant::now();
-    let result =
-        generate_pyramid_streaming(&strip_src, plan, &sink, &config, &observer).unwrap();
+    let result = EngineBuilder::new(strip_src, plan.clone(), &sink)
+        .with_engine(EngineKind::Streaming)
+        .with_config(engine_config)
+        .with_memory_budget(memory_budget_bytes)
+        .with_budget_policy(BudgetPolicy::Error)
+        .with_observer_arc(observer.clone())
+        .run()
+        .unwrap();
     let wall_time = start.elapsed();
 
     let strips = observer
@@ -220,19 +227,21 @@ pub fn bench_mapreduce(
     label: &str,
 ) -> RunMetrics {
     let sink = MemorySink::new();
-    let observer = CollectingObserver::new();
-    let config = MapReduceConfig {
-        memory_budget_bytes,
-        tile_concurrency,
-        buffer_size: 64,
-        background_rgb: [255, 255, 255],
-        blank_tile_strategy: libviprs::BlankTileStrategy::Emit,
-    };
-
+    let observer = Arc::new(CollectingObserver::new());
+    let engine_config = EngineConfig::default()
+        .with_concurrency(tile_concurrency)
+        .with_buffer_size(64)
+        .with_blank_tile_strategy(libviprs::BlankTileStrategy::Emit);
     let strip_src = RasterStripSource::new(src);
     let start = Instant::now();
-    let result =
-        generate_pyramid_mapreduce(&strip_src, plan, &sink, &config, &observer).unwrap();
+    let result = EngineBuilder::new(strip_src, plan.clone(), &sink)
+        .with_engine(EngineKind::MapReduce)
+        .with_config(engine_config)
+        .with_memory_budget(memory_budget_bytes)
+        .with_budget_policy(BudgetPolicy::Error)
+        .with_observer_arc(observer.clone())
+        .run()
+        .unwrap();
     let wall_time = start.elapsed();
 
     let events = observer.events();
@@ -356,10 +365,7 @@ pub fn bench_libvips(
     let output = match output {
         Ok(o) if o.status.success() => o,
         Ok(o) => {
-            eprintln!(
-                "vips dzsave failed: {}",
-                String::from_utf8_lossy(&o.stderr)
-            );
+            eprintln!("vips dzsave failed: {}", String::from_utf8_lossy(&o.stderr));
             let _ = std::fs::remove_dir_all(&out_dir);
             return None;
         }
@@ -394,7 +400,12 @@ pub fn bench_libvips(
             .lines()
             .find_map(|line| {
                 if line.contains("Maximum resident set size") {
-                    line.split(':').nth(1)?.trim().parse::<u64>().ok().map(|kb| kb * 1024)
+                    line.split(':')
+                        .nth(1)?
+                        .trim()
+                        .parse::<u64>()
+                        .ok()
+                        .map(|kb| kb * 1024)
                 } else {
                     None
                 }
@@ -413,7 +424,11 @@ pub fn bench_libvips(
     // Count levels (subdirectories)
     let levels_processed = if tiles_dir.exists() {
         std::fs::read_dir(&tiles_dir)
-            .map(|rd| rd.filter_map(|e| e.ok()).filter(|e| e.path().is_dir()).count() as u32)
+            .map(|rd| {
+                rd.filter_map(|e| e.ok())
+                    .filter(|e| e.path().is_dir())
+                    .count() as u32
+            })
             .unwrap_or(0)
     } else {
         0
@@ -514,9 +529,12 @@ pub fn bench_libvips_inprocess(
         libvips_rs::bindings::vips_dzsave(
             img,
             dz_path_c.as_ptr(),
-            tile_size_c.as_ptr(), tile_size as i32,
-            overlap_c.as_ptr(), 0i32,
-            suffix_opt_c.as_ptr(), suffix_c.as_ptr(),
+            tile_size_c.as_ptr(),
+            tile_size as i32,
+            overlap_c.as_ptr(),
+            0i32,
+            suffix_opt_c.as_ptr(),
+            suffix_c.as_ptr(),
             std::ptr::null::<std::ffi::c_void>(),
         )
     };
@@ -543,7 +561,11 @@ pub fn bench_libvips_inprocess(
 
     let levels_processed = if tiles_dir.exists() {
         std::fs::read_dir(&tiles_dir)
-            .map(|rd| rd.filter_map(|e| e.ok()).filter(|e| e.path().is_dir()).count() as u32)
+            .map(|rd| {
+                rd.filter_map(|e| e.ok())
+                    .filter(|e| e.path().is_dir())
+                    .count() as u32
+            })
             .unwrap_or(0)
     } else {
         0
@@ -678,20 +700,18 @@ pub fn comparison_suite(
             let mut vips_done = false;
             #[cfg(feature = "libvips")]
             {
-                if let Some(vips) = bench_libvips_inprocess(
-                    &src, tile_size, conc,
-                    &format!("{label}_vips"),
-                ) {
+                if let Some(vips) =
+                    bench_libvips_inprocess(&src, tile_size, conc, &format!("{label}_vips"))
+                {
                     results.push(vips);
                     vips_done = true;
                 }
             }
             if !vips_done {
                 if let Some(ref png) = png_path {
-                    if let Some(vips) = bench_libvips(
-                        png, w, h, tile_size, conc,
-                        &format!("{label}_vips"),
-                    ) {
+                    if let Some(vips) =
+                        bench_libvips(png, w, h, tile_size, conc, &format!("{label}_vips"))
+                    {
                         results.push(vips);
                     }
                 }
@@ -780,10 +800,10 @@ pub fn create_snapshot(
 use plotters::prelude::*;
 
 /// Color palette for the four engines.
-const COLOR_VIPS: RGBColor = RGBColor(156, 39, 176);    // purple — libvips
-const COLOR_MONO: RGBColor = RGBColor(66, 133, 244);    // blue   — monolithic
-const COLOR_STREAM: RGBColor = RGBColor(52, 168, 83);   // green  — streaming
-const COLOR_MR: RGBColor = RGBColor(234, 67, 53);       // red    — mapreduce
+const COLOR_VIPS: RGBColor = RGBColor(156, 39, 176); // purple — libvips
+const COLOR_MONO: RGBColor = RGBColor(66, 133, 244); // blue   — monolithic
+const COLOR_STREAM: RGBColor = RGBColor(52, 168, 83); // green  — streaming
+const COLOR_MR: RGBColor = RGBColor(234, 67, 53); // red    — mapreduce
 
 /// Grouped bar chart data.
 struct ChartGroup {
@@ -793,10 +813,7 @@ struct ChartGroup {
 
 /// Extract chart groups from results. Groups by (width, height, concurrency).
 /// Each group contains one bar per engine found.
-fn extract_groups(
-    results: &[RunMetrics],
-    metric: fn(&RunMetrics) -> f64,
-) -> Vec<ChartGroup> {
+fn extract_groups(results: &[RunMetrics], metric: fn(&RunMetrics) -> f64) -> Vec<ChartGroup> {
     // Group results by config key
     let mut map: std::collections::BTreeMap<String, Vec<&RunMetrics>> =
         std::collections::BTreeMap::new();
@@ -1086,7 +1103,11 @@ pub fn generate_history_chart(
 
     // Draw lines for each engine
     let mut draw_line = |pts: &[Point], color: RGBColor, name: &str| {
-        let series: Vec<(usize, f64)> = pts.iter().enumerate().map(|(i, p)| (i, p.wall_time_ms)).collect();
+        let series: Vec<(usize, f64)> = pts
+            .iter()
+            .enumerate()
+            .map(|(i, p)| (i, p.wall_time_ms))
+            .collect();
         if !series.is_empty() {
             chart
                 .draw_series(LineSeries::new(series.clone(), color.stroke_width(2)))
@@ -1096,7 +1117,11 @@ pub fn generate_history_chart(
                     Rectangle::new([(x, y - 5), (x + 15, y + 5)], color.filled())
                 });
             chart
-                .draw_series(series.iter().map(|&(x, y)| Circle::new((x, y), 3, color.filled())))
+                .draw_series(
+                    series
+                        .iter()
+                        .map(|&(x, y)| Circle::new((x, y), 3, color.filled())),
+                )
                 .unwrap();
         }
     };
@@ -1154,7 +1179,11 @@ pub fn generate_history_chart(
         .unwrap();
 
     let mut draw_mem_line = |pts: &[Point], color: RGBColor, name: &str| {
-        let series: Vec<(usize, f64)> = pts.iter().enumerate().map(|(i, p)| (i, p.peak_memory_mb)).collect();
+        let series: Vec<(usize, f64)> = pts
+            .iter()
+            .enumerate()
+            .map(|(i, p)| (i, p.peak_memory_mb))
+            .collect();
         if !series.is_empty() {
             chart
                 .draw_series(LineSeries::new(series.clone(), color.stroke_width(2)))
@@ -1164,7 +1193,11 @@ pub fn generate_history_chart(
                     Rectangle::new([(x, y - 5), (x + 15, y + 5)], color.filled())
                 });
             chart
-                .draw_series(series.iter().map(|&(x, y)| Circle::new((x, y), 3, color.filled())))
+                .draw_series(
+                    series
+                        .iter()
+                        .map(|&(x, y)| Circle::new((x, y), 3, color.filled())),
+                )
                 .unwrap();
         }
     };
@@ -1198,7 +1231,10 @@ pub fn print_savings_summary(results: &[RunMetrics]) {
     println!("{}", "-".repeat(86));
 
     for group in &groups {
-        let config = format!("{}x{} c{}", group[0].width, group[0].height, group[0].concurrency);
+        let config = format!(
+            "{}x{} c{}",
+            group[0].width, group[0].height, group[0].concurrency
+        );
         for (i, r) in group.iter().enumerate() {
             let label = if i == 0 { &config } else { "" };
             println!(

--- a/src/pdfium_strip_source_bench.rs
+++ b/src/pdfium_strip_source_bench.rs
@@ -1,0 +1,243 @@
+//! Cached-vs-streaming `PdfiumStripSource` benchmark.
+//!
+//! Compares the two `PdfiumStripSource` constructors over a parametric
+//! sweep of `(dpi, strip_count)` on a user-supplied PDF, producing
+//! wall-time and peak-RSS numbers for each combination. The numbers
+//! back the doc comments on `PdfiumStripSource::new_streaming` —
+//! "vector-heavy PDFs scale ~linearly with N, raster-heavy approach
+//! 1×" — with empirical data instead of assertion.
+//!
+//! # Usage
+//!
+//! ```sh
+//! cargo run --release --bin pdfium_strip_source_bench -- \
+//!     --pdf /path/to/blueprint.pdf \
+//!     --page 1 \
+//!     --dpis 72,150,300 \
+//!     --strip-counts 4,16,64 \
+//!     --output bench-strip-source.json
+//! ```
+//!
+//! # Output
+//!
+//! Newline-delimited JSON: one `BenchRecord` per `(mode, dpi, strips)`
+//! triple. Suitable for grep / jq / awk piping.
+
+#![cfg(feature = "pdfium")]
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use libviprs::PdfiumStripSource;
+use libviprs::streaming::StripSource;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+struct BenchRecord {
+    fixture: String,
+    page: usize,
+    mode: &'static str,
+    dpi: u32,
+    strips: u32,
+    wall_time_ms: f64,
+    /// Peak resident set size of the whole process at the end of the run,
+    /// in bytes. NOT the per-source allocation — getrusage `ru_maxrss`
+    /// is a high-water-mark across the entire process lifetime, so it
+    /// only meaningfully diff'd between fresh subprocess invocations.
+    peak_rss_bytes: u64,
+    /// Raster width reported by the source.
+    width: u32,
+    /// Raster height reported by the source.
+    height: u32,
+}
+
+#[cfg(target_os = "macos")]
+fn peak_rss_bytes() -> u64 {
+    use libc::{RUSAGE_SELF, getrusage, rusage};
+    unsafe {
+        let mut usage: rusage = std::mem::zeroed();
+        if getrusage(RUSAGE_SELF, &mut usage) == 0 {
+            // ru_maxrss is bytes on macOS, KB on Linux.
+            usage.ru_maxrss as u64
+        } else {
+            0
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn peak_rss_bytes() -> u64 {
+    use libc::{RUSAGE_SELF, getrusage, rusage};
+    unsafe {
+        let mut usage: rusage = std::mem::zeroed();
+        if getrusage(RUSAGE_SELF, &mut usage) == 0 {
+            (usage.ru_maxrss as u64) * 1024
+        } else {
+            0
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn peak_rss_bytes() -> u64 {
+    0
+}
+
+struct Args {
+    pdf_path: PathBuf,
+    page: usize,
+    dpis: Vec<u32>,
+    strip_counts: Vec<u32>,
+    output: Option<PathBuf>,
+}
+
+fn parse_args() -> Args {
+    let mut pdf_path: Option<PathBuf> = None;
+    let mut page: usize = 1;
+    let mut dpis: Vec<u32> = vec![72, 150];
+    let mut strip_counts: Vec<u32> = vec![4, 16];
+    let mut output: Option<PathBuf> = None;
+
+    let mut iter = std::env::args().skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--pdf" => {
+                pdf_path = Some(PathBuf::from(iter.next().unwrap_or_else(|| {
+                    eprintln!("--pdf requires a path argument");
+                    std::process::exit(2);
+                })));
+            }
+            "--page" => {
+                page = iter.next().and_then(|s| s.parse().ok()).unwrap_or_else(|| {
+                    eprintln!("--page requires a positive integer");
+                    std::process::exit(2);
+                });
+            }
+            "--dpis" => {
+                dpis = parse_csv_u32(&iter.next().unwrap_or_default());
+            }
+            "--strip-counts" => {
+                strip_counts = parse_csv_u32(&iter.next().unwrap_or_default());
+            }
+            "--output" => {
+                output = iter.next().map(PathBuf::from);
+            }
+            "-h" | "--help" => {
+                eprintln!(
+                    "usage: pdfium_strip_source_bench --pdf <path> [--page N] \
+                     [--dpis 72,150,300] [--strip-counts 4,16,64] [--output file.jsonl]"
+                );
+                std::process::exit(0);
+            }
+            _ => {
+                eprintln!("unknown argument: {arg}");
+                std::process::exit(2);
+            }
+        }
+    }
+
+    let pdf_path = pdf_path.unwrap_or_else(|| {
+        eprintln!("--pdf is required");
+        std::process::exit(2);
+    });
+
+    Args {
+        pdf_path,
+        page,
+        dpis,
+        strip_counts,
+        output,
+    }
+}
+
+fn parse_csv_u32(s: &str) -> Vec<u32> {
+    s.split(',').filter_map(|t| t.trim().parse().ok()).collect()
+}
+
+fn main() {
+    let args = parse_args();
+
+    let fixture_label = args
+        .pdf_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let mut writer: Box<dyn std::io::Write> = match &args.output {
+        Some(path) => Box::new(std::fs::File::create(path).unwrap_or_else(|e| {
+            eprintln!("failed to create {}: {e}", path.display());
+            std::process::exit(1);
+        })),
+        None => Box::new(std::io::stdout()),
+    };
+
+    eprintln!(
+        "fixture={} page={} dpis={:?} strip_counts={:?}",
+        fixture_label, args.page, args.dpis, args.strip_counts
+    );
+
+    for &dpi in &args.dpis {
+        for &strips in &args.strip_counts {
+            for &mode in &["cached", "streaming"] {
+                let record = bench_one(&args.pdf_path, args.page, dpi, strips, mode);
+                let json = serde_json::to_string(&BenchRecord {
+                    fixture: fixture_label.clone(),
+                    ..record
+                })
+                .expect("serialize record");
+                writeln!(writer, "{json}").expect("write");
+                eprintln!(
+                    "{:>9} dpi={:>3} strips={:>2} ⇒ {:>7.1} ms",
+                    mode, dpi, strips, record.wall_time_ms,
+                );
+            }
+        }
+    }
+}
+
+/// Run one bench iteration. Returns a partial `BenchRecord` (the
+/// caller fills in `fixture`).
+fn bench_one(
+    pdf_path: &std::path::Path,
+    page: usize,
+    dpi: u32,
+    strips: u32,
+    mode: &'static str,
+) -> BenchRecord {
+    let start = Instant::now();
+    let source = match mode {
+        "cached" => PdfiumStripSource::new(pdf_path, page, dpi),
+        "streaming" => PdfiumStripSource::new_streaming(pdf_path, page, dpi),
+        _ => unreachable!("mode is selected from the literal slice above"),
+    }
+    .unwrap_or_else(|e| {
+        eprintln!("source construction failed for {mode}: {e:?}");
+        std::process::exit(1);
+    });
+
+    let h_total = source.height();
+    let strip_h = (h_total / strips).max(1);
+    let mut y = 0u32;
+    while y < h_total {
+        let cur_h = strip_h.min(h_total - y);
+        let _strip = source.render_strip(y, cur_h).unwrap_or_else(|e| {
+            eprintln!("render_strip failed for {mode}: {e:?}");
+            std::process::exit(1);
+        });
+        y += cur_h;
+    }
+    let wall_time_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+    BenchRecord {
+        fixture: String::new(), // caller fills
+        page,
+        mode,
+        dpi,
+        strips,
+        wall_time_ms,
+        peak_rss_bytes: peak_rss_bytes(),
+        width: source.width(),
+        height: source.height(),
+    }
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -27,12 +27,7 @@ fn main() {
     let report_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("report");
     fs::create_dir_all(&report_dir).unwrap();
 
-    let sizes: &[(u32, u32)] = &[
-        (512, 512),
-        (1024, 1024),
-        (2048, 2048),
-        (4096, 4096),
-    ];
+    let sizes: &[(u32, u32)] = &[(512, 512), (1024, 1024), (2048, 2048), (4096, 4096)];
     let concurrency_levels: &[usize] = &[0, 4];
     let tile_size: u32 = 256;
     let streaming_budget: u64 = 1_000_000; // 1 MB
@@ -43,7 +38,10 @@ fn main() {
     println!("Tile size: {tile_size}, memory budget: {streaming_budget} bytes");
     println!(
         "Image sizes: {:?}",
-        sizes.iter().map(|(w, h)| format!("{w}x{h}")).collect::<Vec<_>>()
+        sizes
+            .iter()
+            .map(|(w, h)| format!("{w}x{h}"))
+            .collect::<Vec<_>>()
     );
     println!("Concurrency levels: {concurrency_levels:?}");
     println!();

--- a/src/scalability.rs
+++ b/src/scalability.rs
@@ -27,6 +27,18 @@ use libviprs_bench::{bench_libvips, gradient_raster, vips_available, write_temp_
 const TILE_SIZE: u32 = 256;
 const STREAMING_BUDGET: u64 = 4_000_000; // 4 MB — forces streaming behavior
 
+/// Default x-axis crop (megapixels) for scalability charts.
+///
+/// The smallest images we benchmark (sub-megapixel up to ~12 MP) sit in a
+/// regime where libvips's per-region working set and the libviprs engines'
+/// fixed setup costs dominate the metrics. On efficiency / resource-cost
+/// charts this manifests as a near-vertical drop on the left side of the
+/// graph that hides the trend in the size range users actually care about
+/// (full-page blueprints at 72 DPI live near 15 MP and above). We crop the
+/// x-axis at this value by default; `--no-crop` falls back to showing the
+/// full series.
+const DEFAULT_X_AXIS_CROP_MP: f64 = 15.0;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ScalabilityPoint {
     width: u32,
@@ -141,13 +153,38 @@ fn draw_scalability_chart(
     x_label: &str,
     y_label: &str,
     series: &[(&str, RGBColor, &[(f64, f64)])],
+    // When `Some(v)`, the chart's x-axis starts at `v` and any data
+    // points with x < v are dropped before plotting. The y-axis range
+    // is recomputed from only the visible points so labels suit the
+    // zoomed-in scale. When `None`, behaves like the original chart
+    // (axis from 0, full series).
+    x_min: Option<f64>,
 ) {
-    let max_x = series
+    let x_lo = x_min.unwrap_or(0.0);
+
+    // Filter every series to the visible x range up-front. Plotters would
+    // clip out-of-range points on its own, but we still need the filtered
+    // view to drive y-axis sizing — otherwise a huge off-chart point keeps
+    // the y-axis stretched and the visible range looks flat against the
+    // axis.
+    let visible_series: Vec<(&str, RGBColor, Vec<(f64, f64)>)> = series
+        .iter()
+        .map(|(name, color, pts)| {
+            let visible: Vec<(f64, f64)> = pts
+                .iter()
+                .filter(|(x, _)| *x >= x_lo)
+                .copied()
+                .collect();
+            (*name, *color, visible)
+        })
+        .collect();
+
+    let max_x = visible_series
         .iter()
         .flat_map(|(_, _, pts)| pts.iter().map(|(x, _)| *x))
-        .fold(0.0f64, f64::max)
+        .fold(x_lo, f64::max)
         * 1.05;
-    let max_y = series
+    let max_y = visible_series
         .iter()
         .flat_map(|(_, _, pts)| pts.iter().map(|(_, y)| *y))
         .fold(0.0f64, f64::max)
@@ -156,12 +193,18 @@ fn draw_scalability_chart(
     let root = SVGBackend::new(path, (700, 450)).into_drawing_area();
     root.fill(&WHITE).unwrap();
 
+    let display_title: String = if x_min.is_some() {
+        format!("{title}  (x ≥ {x_lo:.0} MP)")
+    } else {
+        title.to_string()
+    };
+
     let mut chart = ChartBuilder::on(&root)
-        .caption(title, ("sans-serif", 18).into_font())
+        .caption(display_title, ("sans-serif", 18).into_font())
         .margin(15)
         .x_label_area_size(40)
         .y_label_area_size(70)
-        .build_cartesian_2d(0.0..max_x, 0.0..max_y)
+        .build_cartesian_2d(x_lo..max_x, 0.0..max_y)
         .unwrap();
 
     chart
@@ -171,13 +214,16 @@ fn draw_scalability_chart(
         .draw()
         .unwrap();
 
-    for (name, color, pts) in series {
-        let data: Vec<(f64, f64)> = pts.to_vec();
+    for (name, color, pts) in &visible_series {
+        let data = pts.clone();
+        let legend_color = *color;
         chart
             .draw_series(LineSeries::new(data.clone(), color.stroke_width(2)))
             .unwrap()
             .label(*name)
-            .legend(move |(x, y)| Rectangle::new([(x, y - 5), (x + 15, y + 5)], color.filled()));
+            .legend(move |(x, y)| {
+                Rectangle::new([(x, y - 5), (x + 15, y + 5)], legend_color.filled())
+            });
         chart
             .draw_series(
                 data.iter()
@@ -198,9 +244,202 @@ fn draw_scalability_chart(
     root.present().unwrap();
 }
 
+/// Render the five scalability SVGs into `report_dir`. Shared between
+/// the bench-then-render path and the `--replot` path.
+fn render_charts(
+    all_points: &[ScalabilityPoint],
+    report_dir: &std::path::Path,
+    x_min: Option<f64>,
+) {
+    let vips_color = RGBColor(156, 39, 176);
+    let mono_color = RGBColor(66, 133, 244);
+    let stream_color = RGBColor(52, 168, 83);
+    let mr_color = RGBColor(234, 67, 53);
+
+    let extract_series = |engine: &str| -> Vec<(f64, f64, f64, f64, f64, f64)> {
+        all_points
+            .iter()
+            .filter(|p| p.engine == engine)
+            .map(|p| {
+                (
+                    p.megapixels,
+                    p.wall_time_ms,
+                    p.peak_memory_mb,
+                    p.tiles_per_second,
+                    p.tiles_per_second_per_mb,
+                    p.resource_cost,
+                )
+            })
+            .collect()
+    };
+
+    let vips_data = extract_series("libvips");
+    let mono_data = extract_series("monolithic");
+    let stream_data = extract_series("streaming");
+    let mr_data = extract_series("mapreduce");
+
+    // Helper to pull one metric (by tuple field index) from each engine's
+    // (megapixels, m1, m2, m3, m4, m5) tuples.
+    macro_rules! xy {
+        ($data:expr, $idx:tt) => {
+            $data.iter().map(|d| (d.0, d.$idx)).collect::<Vec<_>>()
+        };
+    }
+
+    // Per-chart definition: (filename, title, y-label, tuple-index for the
+    // metric on each engine's series). Looping over this avoids repeating
+    // the build-up boilerplate five times.
+    let charts: [(&str, &str, &str, u8); 5] = [
+        (
+            "scalability_wall_time.svg",
+            "Wall Time Scalability — 43551_California_South.pdf",
+            "Time (ms)",
+            1,
+        ),
+        (
+            "scalability_peak_memory.svg",
+            "Peak Memory Scalability — 43551_California_South.pdf",
+            "Peak Memory (MB)",
+            2,
+        ),
+        (
+            "scalability_throughput.svg",
+            "Throughput Scalability — 43551_California_South.pdf",
+            "Tiles/s",
+            3,
+        ),
+        (
+            "scalability_efficiency.svg",
+            "Memory Efficiency Scalability — Tiles/s per MB",
+            "Tiles/s/MB",
+            4,
+        ),
+        (
+            "scalability_resource_cost.svg",
+            "Resource Cost Scalability — MB\u{00b7}s per Tile (lower is better)",
+            "MB\u{00b7}s / tile",
+            5,
+        ),
+    ];
+
+    for (filename, title, y_label, idx) in charts {
+        let mut series: Vec<(&str, RGBColor, Vec<(f64, f64)>)> = Vec::new();
+        if !vips_data.is_empty() {
+            let pts = match idx {
+                1 => xy!(vips_data, 1),
+                2 => xy!(vips_data, 2),
+                3 => xy!(vips_data, 3),
+                4 => xy!(vips_data, 4),
+                5 => xy!(vips_data, 5),
+                _ => unreachable!(),
+            };
+            series.push(("libvips", vips_color, pts));
+        }
+        let pts_for = |data: &Vec<(f64, f64, f64, f64, f64, f64)>| match idx {
+            1 => xy!(data, 1),
+            2 => xy!(data, 2),
+            3 => xy!(data, 3),
+            4 => xy!(data, 4),
+            5 => xy!(data, 5),
+            _ => unreachable!(),
+        };
+        series.push(("Monolithic", mono_color, pts_for(&mono_data)));
+        series.push(("Streaming", stream_color, pts_for(&stream_data)));
+        series.push(("MapReduce", mr_color, pts_for(&mr_data)));
+
+        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> = series
+            .iter()
+            .map(|(n, c, d)| (*n, *c, d.as_slice()))
+            .collect();
+
+        draw_scalability_chart(
+            &report_dir.join(filename),
+            title,
+            "Image Size (megapixels)",
+            y_label,
+            &refs,
+            x_min,
+        );
+    }
+}
+
+/// Parsed CLI options for the scalability binary.
+struct CliOpts {
+    /// When true, skip the bench loop and re-render charts from the
+    /// `scalability_results.json` already on disk. Useful for iterating on
+    /// chart styling without paying the multi-minute bench cost.
+    replot: bool,
+    /// When true, draw charts with the original full-range x-axis. When
+    /// false (the default), x-axis starts at `DEFAULT_X_AXIS_CROP_MP` so
+    /// the steep-slope startup region is hidden.
+    no_crop: bool,
+}
+
+fn parse_cli() -> CliOpts {
+    let mut replot = false;
+    let mut no_crop = false;
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "--replot" => replot = true,
+            "--no-crop" | "--full-x-range" => no_crop = true,
+            "-h" | "--help" => {
+                println!("Usage: scalability [--replot] [--no-crop]");
+                println!();
+                println!("  --replot     Skip the bench; redraw SVGs from the existing");
+                println!("               report/scalability_results.json.");
+                println!("  --no-crop    Disable the default x-axis crop ({} MP) so the", DEFAULT_X_AXIS_CROP_MP);
+                println!("               startup region of every chart is visible again.");
+                std::process::exit(0);
+            }
+            other => {
+                eprintln!("Unknown argument: {other}");
+                eprintln!("Run with --help for usage.");
+                std::process::exit(2);
+            }
+        }
+    }
+    CliOpts { replot, no_crop }
+}
+
 fn main() {
+    let opts = parse_cli();
+    let x_axis_crop: Option<f64> = if opts.no_crop {
+        None
+    } else {
+        Some(DEFAULT_X_AXIS_CROP_MP)
+    };
+
     let report_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("report");
     fs::create_dir_all(&report_dir).unwrap();
+
+    // Replot mode: skip the bench, reload points from JSON, jump straight
+    // to chart generation. Lets us iterate on chart styling (cropping,
+    // colors, captions) without paying the multi-minute bench cost.
+    if opts.replot {
+        let json_path = report_dir.join("scalability_results.json");
+        let raw = fs::read_to_string(&json_path).unwrap_or_else(|e| {
+            eprintln!("--replot needs an existing {}: {e}", json_path.display());
+            std::process::exit(1);
+        });
+        let all_points: Vec<ScalabilityPoint> = serde_json::from_str(&raw).unwrap_or_else(|e| {
+            eprintln!("failed to parse {}: {e}", json_path.display());
+            std::process::exit(1);
+        });
+        println!(
+            "Replotting {} points from {} (crop: {})",
+            all_points.len(),
+            json_path.display(),
+            x_axis_crop
+                .map(|v| format!(">= {v} MP"))
+                .unwrap_or_else(|| "off".to_string()),
+        );
+        render_charts(&all_points, &report_dir, x_axis_crop);
+        println!(
+            "Charts written to {}/scalability_*.svg",
+            report_dir.display()
+        );
+        return;
+    }
 
     let has_vips = vips_available();
 
@@ -309,160 +548,7 @@ fn main() {
     }
 
     // --- Generate charts ---
-
-    let vips_color = RGBColor(156, 39, 176);
-    let mono_color = RGBColor(66, 133, 244);
-    let stream_color = RGBColor(52, 168, 83);
-    let mr_color = RGBColor(234, 67, 53);
-
-    let extract_series = |engine: &str| -> Vec<(f64, f64, f64, f64, f64, f64)> {
-        all_points
-            .iter()
-            .filter(|p| p.engine == engine)
-            .map(|p| {
-                (
-                    p.megapixels,
-                    p.wall_time_ms,
-                    p.peak_memory_mb,
-                    p.tiles_per_second,
-                    p.tiles_per_second_per_mb,
-                    p.resource_cost,
-                )
-            })
-            .collect()
-    };
-
-    let vips_data = extract_series("libvips");
-    let mono_data = extract_series("monolithic");
-    let stream_data = extract_series("streaming");
-    let mr_data = extract_series("mapreduce");
-
-    // Helper to pull one metric from the tuple series
-    macro_rules! xy {
-        ($data:expr, $idx:tt) => {
-            $data.iter().map(|d| (d.0, d.$idx)).collect::<Vec<_>>()
-        };
-    }
-
-    // 1. Wall time vs megapixels
-    {
-        let mut series: Vec<(&str, RGBColor, Vec<(f64, f64)>)> = Vec::new();
-        if !vips_data.is_empty() {
-            series.push(("libvips", vips_color, xy!(vips_data, 1)));
-        }
-        series.push(("Monolithic", mono_color, xy!(mono_data, 1)));
-        series.push(("Streaming", stream_color, xy!(stream_data, 1)));
-        series.push(("MapReduce", mr_color, xy!(mr_data, 1)));
-
-        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> = series
-            .iter()
-            .map(|(n, c, d)| (*n, *c, d.as_slice()))
-            .collect();
-
-        draw_scalability_chart(
-            &report_dir.join("scalability_wall_time.svg"),
-            "Wall Time Scalability — 43551_California_South.pdf",
-            "Image Size (megapixels)",
-            "Time (ms)",
-            &refs,
-        );
-    }
-
-    // 2. Peak memory vs megapixels
-    {
-        let mut series: Vec<(&str, RGBColor, Vec<(f64, f64)>)> = Vec::new();
-        if !vips_data.is_empty() {
-            series.push(("libvips", vips_color, xy!(vips_data, 2)));
-        }
-        series.push(("Monolithic", mono_color, xy!(mono_data, 2)));
-        series.push(("Streaming", stream_color, xy!(stream_data, 2)));
-        series.push(("MapReduce", mr_color, xy!(mr_data, 2)));
-
-        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> = series
-            .iter()
-            .map(|(n, c, d)| (*n, *c, d.as_slice()))
-            .collect();
-
-        draw_scalability_chart(
-            &report_dir.join("scalability_peak_memory.svg"),
-            "Peak Memory Scalability — 43551_California_South.pdf",
-            "Image Size (megapixels)",
-            "Peak Memory (MB)",
-            &refs,
-        );
-    }
-
-    // 3. Throughput vs megapixels
-    {
-        let mut series: Vec<(&str, RGBColor, Vec<(f64, f64)>)> = Vec::new();
-        if !vips_data.is_empty() {
-            series.push(("libvips", vips_color, xy!(vips_data, 3)));
-        }
-        series.push(("Monolithic", mono_color, xy!(mono_data, 3)));
-        series.push(("Streaming", stream_color, xy!(stream_data, 3)));
-        series.push(("MapReduce", mr_color, xy!(mr_data, 3)));
-
-        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> = series
-            .iter()
-            .map(|(n, c, d)| (*n, *c, d.as_slice()))
-            .collect();
-
-        draw_scalability_chart(
-            &report_dir.join("scalability_throughput.svg"),
-            "Throughput Scalability — 43551_California_South.pdf",
-            "Image Size (megapixels)",
-            "Tiles/s",
-            &refs,
-        );
-    }
-
-    // 4. Memory efficiency vs megapixels
-    {
-        let mut series: Vec<(&str, RGBColor, Vec<(f64, f64)>)> = Vec::new();
-        if !vips_data.is_empty() {
-            series.push(("libvips", vips_color, xy!(vips_data, 4)));
-        }
-        series.push(("Monolithic", mono_color, xy!(mono_data, 4)));
-        series.push(("Streaming", stream_color, xy!(stream_data, 4)));
-        series.push(("MapReduce", mr_color, xy!(mr_data, 4)));
-
-        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> = series
-            .iter()
-            .map(|(n, c, d)| (*n, *c, d.as_slice()))
-            .collect();
-
-        draw_scalability_chart(
-            &report_dir.join("scalability_efficiency.svg"),
-            "Memory Efficiency Scalability — Tiles/s per MB",
-            "Image Size (megapixels)",
-            "Tiles/s/MB",
-            &refs,
-        );
-    }
-
-    // 5. Resource cost vs megapixels
-    {
-        let mut series: Vec<(&str, RGBColor, Vec<(f64, f64)>)> = Vec::new();
-        if !vips_data.is_empty() {
-            series.push(("libvips", vips_color, xy!(vips_data, 5)));
-        }
-        series.push(("Monolithic", mono_color, xy!(mono_data, 5)));
-        series.push(("Streaming", stream_color, xy!(stream_data, 5)));
-        series.push(("MapReduce", mr_color, xy!(mr_data, 5)));
-
-        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> = series
-            .iter()
-            .map(|(n, c, d)| (*n, *c, d.as_slice()))
-            .collect();
-
-        draw_scalability_chart(
-            &report_dir.join("scalability_resource_cost.svg"),
-            "Resource Cost Scalability — MB\u{00b7}s per Tile (lower is better)",
-            "Image Size (megapixels)",
-            "MB\u{00b7}s / tile",
-            &refs,
-        );
-    }
+    render_charts(&all_points, &report_dir, x_axis_crop);
 
     // Save raw data
     let json_path = report_dir.join("scalability_results.json");

--- a/src/scalability.rs
+++ b/src/scalability.rs
@@ -17,10 +17,10 @@ use std::time::Instant;
 use plotters::prelude::*;
 use serde::{Deserialize, Serialize};
 
+use libviprs::streaming::BudgetPolicy;
 use libviprs::{
-    EngineConfig, Layout, MapReduceConfig, MemorySink, PyramidPlanner, Raster, RasterStripSource,
-    StreamingConfig, generate_pyramid, generate_pyramid_mapreduce, generate_pyramid_streaming,
-    observe::NoopObserver,
+    EngineBuilder, EngineConfig, EngineKind, Layout, MemorySink, PyramidPlanner, Raster,
+    RasterStripSource,
 };
 use libviprs_bench::{bench_libvips, gradient_raster, vips_available, write_temp_png};
 
@@ -47,8 +47,16 @@ fn run_monolithic(src: &Raster, tile_size: u32) -> (std::time::Duration, u64, u6
     let plan = planner.plan();
     let sink = MemorySink::new();
     let start = Instant::now();
-    let result = generate_pyramid(src, &plan, &sink, &EngineConfig::default()).unwrap();
-    (start.elapsed(), result.peak_memory_bytes, result.tiles_produced)
+    let result = EngineBuilder::new(src, plan, &sink)
+        .with_engine(EngineKind::Monolithic)
+        .with_config(EngineConfig::default())
+        .run()
+        .unwrap();
+    (
+        start.elapsed(),
+        result.peak_memory_bytes,
+        result.tiles_produced,
+    )
 }
 
 fn run_streaming(src: &Raster, tile_size: u32, budget: u64) -> (std::time::Duration, u64, u64) {
@@ -56,16 +64,20 @@ fn run_streaming(src: &Raster, tile_size: u32, budget: u64) -> (std::time::Durat
         PyramidPlanner::new(src.width(), src.height(), tile_size, 0, Layout::DeepZoom).unwrap();
     let plan = planner.plan();
     let sink = MemorySink::new();
-    let config = StreamingConfig {
-        memory_budget_bytes: budget,
-        engine: EngineConfig::default(),
-        budget_policy: libviprs::streaming::BudgetPolicy::Error,
-    };
     let strip_src = RasterStripSource::new(src);
     let start = Instant::now();
-    let result =
-        generate_pyramid_streaming(&strip_src, &plan, &sink, &config, &NoopObserver).unwrap();
-    (start.elapsed(), result.peak_memory_bytes, result.tiles_produced)
+    let result = EngineBuilder::new(strip_src, plan, &sink)
+        .with_engine(EngineKind::Streaming)
+        .with_config(EngineConfig::default())
+        .with_memory_budget(budget)
+        .with_budget_policy(BudgetPolicy::Error)
+        .run()
+        .unwrap();
+    (
+        start.elapsed(),
+        result.peak_memory_bytes,
+        result.tiles_produced,
+    )
 }
 
 fn run_mapreduce(src: &Raster, tile_size: u32, budget: u64) -> (std::time::Duration, u64, u64) {
@@ -73,16 +85,20 @@ fn run_mapreduce(src: &Raster, tile_size: u32, budget: u64) -> (std::time::Durat
         PyramidPlanner::new(src.width(), src.height(), tile_size, 0, Layout::DeepZoom).unwrap();
     let plan = planner.plan();
     let sink = MemorySink::new();
-    let config = MapReduceConfig {
-        memory_budget_bytes: budget,
-        tile_concurrency: 4,
-        ..MapReduceConfig::default()
-    };
     let strip_src = RasterStripSource::new(src);
     let start = Instant::now();
-    let result =
-        generate_pyramid_mapreduce(&strip_src, &plan, &sink, &config, &NoopObserver).unwrap();
-    (start.elapsed(), result.peak_memory_bytes, result.tiles_produced)
+    let result = EngineBuilder::new(strip_src, plan, &sink)
+        .with_engine(EngineKind::MapReduce)
+        .with_config(EngineConfig::default().with_concurrency(4))
+        .with_memory_budget(budget)
+        .with_budget_policy(BudgetPolicy::Error)
+        .run()
+        .unwrap();
+    (
+        start.elapsed(),
+        result.peak_memory_bytes,
+        result.tiles_produced,
+    )
 }
 
 fn to_point(
@@ -163,7 +179,10 @@ fn draw_scalability_chart(
             .label(*name)
             .legend(move |(x, y)| Rectangle::new([(x, y - 5), (x + 15, y + 5)], color.filled()));
         chart
-            .draw_series(data.iter().map(|&(x, y)| Circle::new((x, y), 4, color.filled())))
+            .draw_series(
+                data.iter()
+                    .map(|&(x, y)| Circle::new((x, y), 4, color.filled())),
+            )
             .unwrap();
     }
 
@@ -230,7 +249,14 @@ fn main() {
                     r.wall_time_ms(),
                     r.peak_memory_mb(),
                 );
-                all_points.push(to_point(w, h, "libvips", r.wall_time, r.peak_memory_bytes, r.tiles_produced));
+                all_points.push(to_point(
+                    w,
+                    h,
+                    "libvips",
+                    r.wall_time,
+                    r.peak_memory_bytes,
+                    r.tiles_produced,
+                ));
                 vips_done = true;
             }
         }
@@ -242,7 +268,14 @@ fn main() {
                     r.wall_time_ms(),
                     r.peak_memory_mb(),
                 );
-                all_points.push(to_point(w, h, "libvips", r.wall_time, r.peak_memory_bytes, r.tiles_produced));
+                all_points.push(to_point(
+                    w,
+                    h,
+                    "libvips",
+                    r.wall_time,
+                    r.peak_memory_bytes,
+                    r.tiles_produced,
+                ));
             }
             let _ = fs::remove_file(&png_path);
         }
@@ -321,8 +354,10 @@ fn main() {
         series.push(("Streaming", stream_color, xy!(stream_data, 1)));
         series.push(("MapReduce", mr_color, xy!(mr_data, 1)));
 
-        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> =
-            series.iter().map(|(n, c, d)| (*n, *c, d.as_slice())).collect();
+        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> = series
+            .iter()
+            .map(|(n, c, d)| (*n, *c, d.as_slice()))
+            .collect();
 
         draw_scalability_chart(
             &report_dir.join("scalability_wall_time.svg"),
@@ -343,8 +378,10 @@ fn main() {
         series.push(("Streaming", stream_color, xy!(stream_data, 2)));
         series.push(("MapReduce", mr_color, xy!(mr_data, 2)));
 
-        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> =
-            series.iter().map(|(n, c, d)| (*n, *c, d.as_slice())).collect();
+        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> = series
+            .iter()
+            .map(|(n, c, d)| (*n, *c, d.as_slice()))
+            .collect();
 
         draw_scalability_chart(
             &report_dir.join("scalability_peak_memory.svg"),
@@ -365,8 +402,10 @@ fn main() {
         series.push(("Streaming", stream_color, xy!(stream_data, 3)));
         series.push(("MapReduce", mr_color, xy!(mr_data, 3)));
 
-        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> =
-            series.iter().map(|(n, c, d)| (*n, *c, d.as_slice())).collect();
+        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> = series
+            .iter()
+            .map(|(n, c, d)| (*n, *c, d.as_slice()))
+            .collect();
 
         draw_scalability_chart(
             &report_dir.join("scalability_throughput.svg"),
@@ -387,8 +426,10 @@ fn main() {
         series.push(("Streaming", stream_color, xy!(stream_data, 4)));
         series.push(("MapReduce", mr_color, xy!(mr_data, 4)));
 
-        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> =
-            series.iter().map(|(n, c, d)| (*n, *c, d.as_slice())).collect();
+        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> = series
+            .iter()
+            .map(|(n, c, d)| (*n, *c, d.as_slice()))
+            .collect();
 
         draw_scalability_chart(
             &report_dir.join("scalability_efficiency.svg"),
@@ -409,8 +450,10 @@ fn main() {
         series.push(("Streaming", stream_color, xy!(stream_data, 5)));
         series.push(("MapReduce", mr_color, xy!(mr_data, 5)));
 
-        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> =
-            series.iter().map(|(n, c, d)| (*n, *c, d.as_slice())).collect();
+        let refs: Vec<(&str, RGBColor, &[(f64, f64)])> = series
+            .iter()
+            .map(|(n, c, d)| (*n, *c, d.as_slice()))
+            .collect();
 
         draw_scalability_chart(
             &report_dir.join("scalability_resource_cost.svg"),
@@ -456,7 +499,10 @@ fn main() {
     let largest_mp = largest.0 as f64 * largest.1 as f64 / 1_000_000.0;
 
     // Monolithic bottleneck
-    if let Some(mono) = all_points.iter().find(|p| p.width == largest.0 && p.engine == "monolithic") {
+    if let Some(mono) = all_points
+        .iter()
+        .find(|p| p.width == largest.0 && p.engine == "monolithic")
+    {
         let canvas_bytes = largest.0 as f64 * largest.1 as f64 * 3.0; // RGB8 = 3 bpp
         let canvas_mb = canvas_bytes / (1024.0 * 1024.0);
         println!(
@@ -471,72 +517,65 @@ fn main() {
             "  The source raster ({:.1} MB) is cloned into a canvas-sized buffer.",
             canvas_mb,
         );
-        println!(
-            "  During downscale, the current level + next level coexist in memory,",
-        );
+        println!("  During downscale, the current level + next level coexist in memory,",);
         println!(
             "  producing peak ≈ canvas + canvas/4 = {:.1} MB.",
             canvas_mb * 1.25,
         );
-        println!(
-            "  This scales O(width × height) — doubling image dimensions quadruples memory.",
-        );
+        println!("  This scales O(width × height) — doubling image dimensions quadruples memory.",);
     }
 
     // Streaming bottleneck
-    if let Some(stream) = all_points.iter().find(|p| p.width == largest.0 && p.engine == "streaming") {
+    if let Some(stream) = all_points
+        .iter()
+        .find(|p| p.width == largest.0 && p.engine == "streaming")
+    {
         println!();
         println!(
             "STREAMING at {}x{} ({:.1} MP), budget {} MB:",
-            largest.0, largest.1, largest_mp,
+            largest.0,
+            largest.1,
+            largest_mp,
             STREAMING_BUDGET as f64 / (1024.0 * 1024.0),
         );
         println!(
             "  Peak memory: {:.1} MB — bounded by strip height, not canvas area.",
             stream.peak_memory_mb,
         );
-        println!(
-            "  The engine holds: current strip + accumulator at each pyramid level",
-        );
-        println!(
-            "  (geometric series: strip + strip/4 + strip/16 + ...). Strip height is",
-        );
-        println!(
-            "  maximised within the budget. Memory scales O(width × strip_height),",
-        );
-        println!(
-            "  independent of image height. The bottleneck is strip width (= canvas width).",
-        );
+        println!("  The engine holds: current strip + accumulator at each pyramid level",);
+        println!("  (geometric series: strip + strip/4 + strip/16 + ...). Strip height is",);
+        println!("  maximised within the budget. Memory scales O(width × strip_height),",);
+        println!("  independent of image height. The bottleneck is strip width (= canvas width).",);
     }
 
     // MapReduce bottleneck
-    if let Some(mr) = all_points.iter().find(|p| p.width == largest.0 && p.engine == "mapreduce") {
+    if let Some(mr) = all_points
+        .iter()
+        .find(|p| p.width == largest.0 && p.engine == "mapreduce")
+    {
         println!();
         println!(
             "MAPREDUCE at {}x{} ({:.1} MP), budget {} MB:",
-            largest.0, largest.1, largest_mp,
+            largest.0,
+            largest.1,
+            largest_mp,
             STREAMING_BUDGET as f64 / (1024.0 * 1024.0),
         );
         println!(
             "  Peak memory: {:.1} MB — same strip-bounded model as streaming.",
             mr.peak_memory_mb,
         );
-        println!(
-            "  With K in-flight strips, peak = K × strip_cost + accumulator chain.",
-        );
-        println!(
-            "  The budget was too small for K>1 in-flight strips at this image width,",
-        );
-        println!(
-            "  so memory matches streaming. With a larger budget, K>1 trades memory",
-        );
-        println!(
-            "  for throughput by overlapping strip rendering.",
-        );
+        println!("  With K in-flight strips, peak = K × strip_cost + accumulator chain.",);
+        println!("  The budget was too small for K>1 in-flight strips at this image width,",);
+        println!("  so memory matches streaming. With a larger budget, K>1 trades memory",);
+        println!("  for throughput by overlapping strip rendering.",);
     }
 
     // libvips bottleneck
-    if let Some(vips) = all_points.iter().find(|p| p.width == largest.0 && p.engine == "libvips") {
+    if let Some(vips) = all_points
+        .iter()
+        .find(|p| p.width == largest.0 && p.engine == "libvips")
+    {
         println!();
         println!(
             "LIBVIPS at {}x{} ({:.1} MP):",
@@ -546,29 +585,26 @@ fn main() {
             "  Peak RSS: {:.1} MB — libvips uses a demand-driven pipeline where pixels",
             vips.peak_memory_mb,
         );
-        println!(
-            "  are computed on demand per-region (O(tile_size²) working set). The RSS",
-        );
-        println!(
-            "  measured here includes the OS-level allocation footprint, which is higher",
-        );
-        println!(
-            "  than the logical working set due to memory mapping, page tables, and the",
-        );
-        println!(
-            "  decoded source image cache.",
-        );
+        println!("  are computed on demand per-region (O(tile_size²) working set). The RSS",);
+        println!("  measured here includes the OS-level allocation footprint, which is higher",);
+        println!("  than the logical working set due to memory mapping, page tables, and the",);
+        println!("  decoded source image cache.",);
     }
 
     // Scaling comparison
     println!();
     println!("SCALING SUMMARY:");
     let smallest = sizes.first().unwrap();
-    let scale_factor = (largest.0 as f64 * largest.1 as f64) / (smallest.0 as f64 * smallest.1 as f64);
+    let scale_factor =
+        (largest.0 as f64 * largest.1 as f64) / (smallest.0 as f64 * smallest.1 as f64);
 
     for engine in &["libvips", "monolithic", "streaming", "mapreduce"] {
-        let small = all_points.iter().find(|p| p.width == smallest.0 && p.engine == *engine);
-        let large = all_points.iter().find(|p| p.width == largest.0 && p.engine == *engine);
+        let small = all_points
+            .iter()
+            .find(|p| p.width == smallest.0 && p.engine == *engine);
+        let large = all_points
+            .iter()
+            .find(|p| p.width == largest.0 && p.engine == *engine);
         if let (Some(s), Some(l)) = (small, large) {
             let mem_scale = l.peak_memory_mb / s.peak_memory_mb.max(0.01);
             let time_scale = l.wall_time_ms / s.wall_time_ms.max(0.01);
@@ -580,6 +616,9 @@ fn main() {
     }
 
     println!();
-    println!("Charts written to {}/scalability_*.svg", report_dir.display());
+    println!(
+        "Charts written to {}/scalability_*.svg",
+        report_dir.display()
+    );
     println!("JSON written to {}", json_path.display());
 }


### PR DESCRIPTION
## Summary
- Crops every scalability chart's x-axis to \`>= 15 MP\` by default. The sub-megapixel startup region was producing a near-vertical drop on the left side (efficiency goes from ~7000 tiles/s/MB at 0.18 MP to ~150 at 12 MP) that hid the trend in the size range users actually care about.
- Y-axis is recomputed from the visible (post-crop) points, so labels suit the zoomed-in scale.
- New \`--no-crop\` / \`--full-x-range\` flag falls back to the original full-series rendering.
- New \`--replot\` flag regenerates SVGs from \`report/scalability_results.json\` without rerunning the bench — useful when iterating on chart styling.
- Chart-build boilerplate lifted into a \`render_charts\` helper; both the bench-then-render path and the replot path call it.

## Test plan
- [x] \`cargo check --bin scalability\`
- [x] \`cargo run --release --bin scalability -- --replot\` — regenerated SVGs in \`report/\`; efficiency chart caption now reads "(x ≥ 15 MP)" and y-axis is rescaled.
- [ ] Full bench run on next bench cycle — \`./run-bench.sh scalability\` still works (no signature changes outside this binary).

## Notes
With the current size grid (sizes top out at 47.18 MP, with 14.93 MP just under the threshold), the cropped charts show only the largest data point per series. To get more visible points after cropping, extend the \`sizes\` list in \`scalability.rs\` or lower \`DEFAULT_X_AXIS_CROP_MP\`.