### PR TITLE
Propagate pdfium-render thread-safety fork pin (Refs #149)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,14 @@ required-features = ["pdfium"]
 name = "cross_version"
 path = "src/cross_version.rs"
 required-features = ["polars"]
+# Mirror the core crate's `pdfium-render` thread-safety fork. `[patch]`
+# tables apply only from the build-root manifest, so the pin in
+# `../libviprs/Cargo.toml` does not reach this crate when it is the
+# build root — this crate resolves the unpatched `pdfium-render 0.8.37`
+# from crates.io, whose `ThreadSafePdfiumBindings` acquires the pdfium
+# global mutex only once on `FPDF_InitLibrary` and bypasses it for
+# every other call, segfaulting under concurrent access to a shared
+# `Pdfium`. Keep this pin in lockstep with `../libviprs/Cargo.toml`;
+# drop both once the fork is upstreamed and released.
+[patch.crates-io]
+pdfium-render = { git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/per-call-thread-safety" }


### PR DESCRIPTION
## What

Replicate the core crate's `pdfium-render` thread-safety fork pin into this sibling. `libviprs-bench` is a build root reaching `pdfium-render` via `libviprs/pdfium` (its `pdfium_strip_source_bench` binary requires the feature).

`[patch.crates-io]` tables apply only from the build-root manifest, so the pin in `../libviprs/Cargo.toml` never reached this crate — it resolved the unpatched `pdfium-render 0.8.37` from crates.io. That wrapper (`ThreadSafePdfiumBindings`) acquires the pdfium global mutex only once on `FPDF_InitLibrary` and bypasses it for every other call, segfaulting under concurrent access to a shared `Pdfium`.

## Change

- Add `[patch.crates-io] pdfium-render = { git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/per-call-thread-safety" }`, kept in lockstep with `../libviprs/Cargo.toml`.
- `Cargo.lock` is `.gitignore`d here, so only the manifest pin is committed; a freshly generated lock resolves the git fork (verified locally with `cargo metadata --locked`).

Verified locally with `cargo metadata --locked` / `cargo tree --locked` — resolution is consistent and points at the fork.

Refs libviprs/libviprs#149