### PR TITLE
Make the cross-engine comparison fair (sink/codec/metric/env)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,68 @@
 # ---------------------------------------------------------------------------
 # Dockerfile — libviprs benchmark environment with libvips + PDFium
 #
-# Provides a controlled environment where libvips (C) and libviprs (Rust)
-# run side-by-side with identical inputs, no filesystem I/O advantage for
-# either side. Both use in-memory pipelines for fair comparison.
+# Provides a controlled, fully-pinned environment where libvips (C) and
+# libviprs (Rust) run side-by-side with identical inputs: both write PNG tiles
+# to a real on-disk sink with the same codec, so neither side gets a
+# filesystem-I/O or encoding advantage (issue #153).
 #
 # Build:  docker build -t libviprs-bench .
 # Run:    docker run --rm libviprs-bench
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Pinned inputs. A benchmark is only reproducible if every layer is fixed:
+# a floating base image, an unpinned `libvips-dev`, or a `latest` PDFium
+# would silently change the numbers between runs (issue #153). Bump these
+# deliberately, never implicitly.
+#   PDFIUM_RELEASE  — bblanchon/pdfium-binaries release tag (was `latest`)
+#   LIBVIPS_VERSION — exact Debian bookworm `libvips*` package version
+# The Rust and Debian base images are pinned by tag on the FROM lines below.
+# ---------------------------------------------------------------------------
+ARG PDFIUM_RELEASE=chromium/7934
+# Exact `libvips*` version currently in Debian bookworm. Debian only keeps the
+# newest security build of a package on the live mirror, so this must name the
+# current `8.14.1-3+deb12uN` — bump `N` when a new bookworm security update
+# lands (otherwise `apt-get install` cannot resolve the pinned version).
+ARG LIBVIPS_VERSION=8.14.1-3+deb12u3
+
 # Stage 1: Download PDFium for the target architecture
-FROM debian:bookworm-slim AS pdfium
+FROM debian:bookworm-20250929-slim AS pdfium
 
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
+ARG PDFIUM_RELEASE
+# The release tag contains a `/` (e.g. `chromium/7934`); it must be
+# percent-encoded to `%2F` in the download URL.
 RUN case "${TARGETARCH}" in \
         amd64) PDFIUM_ARCH="linux-x64" ;; \
         arm64) PDFIUM_ARCH="linux-arm64" ;; \
         *)     echo "Unsupported arch: ${TARGETARCH}" && exit 1 ;; \
     esac && \
-    curl -L -o /tmp/pdfium.tgz \
-        "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-${PDFIUM_ARCH}.tgz" && \
+    PDFIUM_TAG_ENC="$(echo "${PDFIUM_RELEASE}" | sed 's#/#%2F#g')" && \
+    curl -fL -o /tmp/pdfium.tgz \
+        "https://github.com/bblanchon/pdfium-binaries/releases/download/${PDFIUM_TAG_ENC}/pdfium-${PDFIUM_ARCH}.tgz" && \
     mkdir -p /opt/pdfium && \
     tar xzf /tmp/pdfium.tgz -C /opt/pdfium && \
     rm /tmp/pdfium.tgz
 
 # Stage 2: Build and run benchmarks
-FROM rust:latest AS builder
+# Pinned Rust (was `rust:latest`) so the compiler and its bundled toolchain
+# do not drift between benchmark runs (issue #153).
+FROM rust:1.89-bookworm AS builder
+
+ARG LIBVIPS_VERSION
 
 # Install libvips development headers and runtime (C library for comparison)
-# plus pkg-config for the build script to find it
+# plus pkg-config for the build script to find it. `libvips*` are pinned to an
+# exact Debian version so the C baseline is fixed run-to-run; bump
+# LIBVIPS_VERSION deliberately when refreshing the environment.
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
         ca-certificates \
-        libvips-dev \
-        libvips-tools \
+        "libvips-dev=${LIBVIPS_VERSION}" \
+        "libvips-tools=${LIBVIPS_VERSION}" \
         pkg-config \
         time \
     && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ This crate is kept in a separate repository so the library crate stays free of h
 
 ## What this is
 
-`libviprs-bench` measures how libviprs scales as image size and concurrency change, and how it compares to libvips on the same workload. Both libraries are linked into a single process so neither side gets a filesystem-I/O advantage.
+`libviprs-bench` measures how libviprs scales as image size and concurrency change, and how it compares to libvips on the same workload. To keep the cross-engine comparison apples-to-apples, every engine — the three libviprs engines and libvips `dzsave` — writes its tiles as **PNG files to a real on-disk sink** under the same DeepZoom layout, so neither side gets an in-RAM-sink or tile-codec advantage.
 
 The harness produces:
 
-- **Wall time** and **peak memory** per engine, per image size
-- **Throughput** (tiles/second) and **memory efficiency** (tiles/second per MB)
-- **Resource cost** (MB-seconds per tile) — useful for comparing engines in environments where memory and CPU time are both billed
+- **Wall time** per engine, per image size
+- **Memory** in two clearly separated columns — an engine-tracked working set (a per-run, libviprs-internal figure; `0` for libvips, which exposes no equivalent) and **peak RSS** (the OS-level high-water mark, measured the same way for every engine). Cross-engine comparison uses the common RSS basis; the two are never conflated.
+- **Throughput** (tiles/second) and **memory efficiency** (tiles/second per RSS-MB)
+- **Resource cost** (RSS-MB-seconds per tile) — useful for comparing engines in environments where memory and CPU time are both billed
 - **SVG charts** of all of the above, plus version-history trend lines across releases
 - **Flame graphs** built from engine observer events
 - **Criterion** statistical reports with violin plots
@@ -36,7 +37,7 @@ The harness produces:
 | **Monolithic** | in-memory `Raster` | Decodes the full canvas, downscales level-by-level. Highest peak memory, fastest at small sizes. |
 | **Streaming** | strip source | Sequential strip pipeline bounded by a memory budget. Memory scales with strip width, not image area. |
 | **MapReduce** | strip source | Parallel strip pipeline. Same strip-bounded model as streaming, with `K` in-flight strips trading memory for throughput. |
-| **libvips** | PNG / raw memory | External baseline via `dzsave`. Either spawned as a CLI or, with the `libvips` feature, called in-process through FFI. |
+| **libvips** | in-memory `VipsImage` | External baseline via `dzsave`, writing PNG tiles to the same on-disk sink as the libviprs engines. Either spawned as a CLI or, with the `libvips` feature, called in-process through FFI. |
 
 | Bench file | Targets |
 |---|---|

--- a/run-bench.sh
+++ b/run-bench.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # run-bench.sh — Build and run libviprs benchmarks in Docker
 #
-# Provides a controlled environment where libvips (C) and libviprs (Rust)
-# run side-by-side with identical inputs. Both libraries are linked into
-# the same process — no CLI spawning, no filesystem I/O advantage.
+# Provides a controlled, pinned environment where libvips (C) and libviprs
+# (Rust) run side-by-side with identical inputs: every engine writes PNG
+# tiles to a real on-disk sink with the same codec, so neither side gets an
+# in-RAM-sink or encoding advantage.
 #
 # Usage:
 #   ./run-bench.sh                     # scalability benchmark (default)

--- a/src/cross_version.rs
+++ b/src/cross_version.rs
@@ -105,7 +105,8 @@ fn build_dataframe(history: &[BenchmarkSnapshot]) -> PolarsResult<DataFrame> {
     let mut engine: Vec<String> = Vec::with_capacity(total);
     let mut concurrency: Vec<u32> = Vec::with_capacity(total);
     let mut wall_time_ms: Vec<f64> = Vec::with_capacity(total);
-    let mut peak_memory_mb: Vec<f64> = Vec::with_capacity(total);
+    let mut tracked_memory_mb: Vec<f64> = Vec::with_capacity(total);
+    let mut peak_rss_mb: Vec<f64> = Vec::with_capacity(total);
     let mut tiles_produced: Vec<u64> = Vec::with_capacity(total);
     let mut tiles_per_second: Vec<f64> = Vec::with_capacity(total);
     let mut tiles_per_second_per_mb: Vec<f64> = Vec::with_capacity(total);
@@ -123,7 +124,8 @@ fn build_dataframe(history: &[BenchmarkSnapshot]) -> PolarsResult<DataFrame> {
             engine.push(run.engine.clone());
             concurrency.push(run.concurrency as u32);
             wall_time_ms.push(run.wall_time_ms());
-            peak_memory_mb.push(run.peak_memory_mb());
+            tracked_memory_mb.push(run.tracked_memory_mb());
+            peak_rss_mb.push(run.peak_rss_mb());
             tiles_produced.push(run.tiles_produced);
             tiles_per_second.push(run.tiles_per_second());
             tiles_per_second_per_mb.push(run.tiles_per_second_per_mb());
@@ -142,7 +144,8 @@ fn build_dataframe(history: &[BenchmarkSnapshot]) -> PolarsResult<DataFrame> {
         "engine" => engine,
         "concurrency" => concurrency,
         "wall_time_ms" => wall_time_ms,
-        "peak_memory_mb" => peak_memory_mb,
+        "tracked_memory_mb" => tracked_memory_mb,
+        "peak_rss_mb" => peak_rss_mb,
         "tiles_produced" => tiles_produced,
         "tiles_per_second" => tiles_per_second,
         "tiles_per_second_per_mb" => tiles_per_second_per_mb,
@@ -189,9 +192,10 @@ fn write_markdown_report(df: &DataFrame, path: &PathBuf) {
         ));
         for metric in [
             ("wall_time_ms", "Wall time (ms)", false),
-            ("peak_memory_mb", "Peak memory (MB)", false),
+            ("tracked_memory_mb", "Tracked working set (MB)", false),
+            ("peak_rss_mb", "Peak RSS (MB)", false),
             ("tiles_per_second", "Throughput (tiles/s)", true),
-            ("tiles_per_second_per_mb", "Efficiency (tiles/s/MB)", true),
+            ("tiles_per_second_per_mb", "Efficiency (tiles/s/RSS-MB)", true),
         ] {
             let (col, title, higher_is_better) = metric;
             out.push_str(&format!("### {title}\n\n"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,19 @@ use std::time::{Duration, Instant};
 
 use libviprs::streaming::BudgetPolicy;
 use libviprs::{
-    CollectingObserver, EngineBuilder, EngineConfig, EngineEvent, EngineKind, Layout, MemorySink,
-    PixelFormat, PyramidPlan, PyramidPlanner, Raster, RasterStripSource,
+    CollectingObserver, EngineBuilder, EngineConfig, EngineEvent, EngineKind, FsSink, Layout,
+    PixelFormat, PyramidPlan, PyramidPlanner, Raster, RasterStripSource, TileFormat,
 };
 use serde::{Deserialize, Serialize};
+
+/// The single tile codec used on **both** sides of the cross-engine
+/// comparison. The libviprs engines encode their tiles in this format via
+/// [`FsSink`], and libvips `dzsave` is invoked with the matching `--suffix`,
+/// so the codec is never a hidden variable between the two engines (issue
+/// #153). Keep [`BENCH_TILE_FORMAT`] and [`BENCH_TILE_SUFFIX`] in lockstep.
+pub const BENCH_TILE_FORMAT: TileFormat = TileFormat::Png;
+/// dzsave `--suffix` (and file extension) matching [`BENCH_TILE_FORMAT`].
+pub const BENCH_TILE_SUFFIX: &str = ".png";
 
 /// A snapshot of benchmark results for a specific libviprs version.
 ///
@@ -45,8 +54,20 @@ pub struct RunMetrics {
     pub engine: String,
     /// Wall-clock time for pyramid generation.
     pub wall_time: Duration,
-    /// Peak tracked memory in bytes (raster buffers only).
-    pub peak_memory_bytes: u64,
+    /// Peak engine-tracked working set in bytes (raster buffers the engine
+    /// accounts for during the run). This is a per-run figure, reset for each
+    /// engine, and is available only for the libviprs engines. libvips does
+    /// not expose an equivalent internal counter, so it is reported as `0`
+    /// there — the two figures are kept in **separate** columns rather than
+    /// being compared against each other (issue #153).
+    pub tracked_memory_bytes: u64,
+    /// Peak resident set size (RSS) in bytes — the OS-level high-water mark.
+    /// This is measured the same way for every engine (via `getrusage` for
+    /// in-process engines, `/usr/bin/time` for the libvips CLI child), so it
+    /// is the one memory basis that is directly comparable across libviprs
+    /// and libvips. See [`RunMetrics::peak_rss_mb`] for the shared-process
+    /// caveat.
+    pub peak_rss_bytes: u64,
     /// Total tiles produced.
     pub tiles_produced: u64,
     /// Levels processed.
@@ -66,8 +87,27 @@ pub struct RunMetrics {
 }
 
 impl RunMetrics {
-    pub fn peak_memory_mb(&self) -> f64 {
-        self.peak_memory_bytes as f64 / (1024.0 * 1024.0)
+    /// Peak engine-tracked working set in MB (libviprs engines; `0` for
+    /// libvips). A per-run, engine-internal figure — not comparable against
+    /// [`RunMetrics::peak_rss_mb`], which is why the two are surfaced as
+    /// separate, labelled columns.
+    pub fn tracked_memory_mb(&self) -> f64 {
+        self.tracked_memory_bytes as f64 / (1024.0 * 1024.0)
+    }
+
+    /// Peak process/child RSS in MB. This is the memory basis that is
+    /// directly comparable across engines and drives the cross-engine
+    /// efficiency and resource-cost metrics below.
+    ///
+    /// Caveat: for the in-process engines several runs share a single
+    /// process and `ru_maxrss` is a monotonic high-water mark, so an
+    /// in-process RSS figure reflects the largest allocation seen in the
+    /// process up to that point rather than a freshly-reset per-run peak.
+    /// The libvips CLI path spawns a child per run and therefore reports a
+    /// strict per-run peak; isolate a single libviprs engine per process for
+    /// the same guarantee.
+    pub fn peak_rss_mb(&self) -> f64 {
+        self.peak_rss_bytes as f64 / (1024.0 * 1024.0)
     }
 
     pub fn wall_time_ms(&self) -> f64 {
@@ -82,15 +122,17 @@ impl RunMetrics {
         }
     }
 
-    /// Memory-normalised throughput: tiles per second per MB of peak memory.
+    /// Memory-normalised throughput on the common RSS basis: tiles per second
+    /// per MB of peak RSS.
     ///
-    /// Captures how efficiently the engine converts memory into work.
-    /// A monolithic engine that processes 300 tiles/s using 48 MB scores
-    /// 6.25, while a streaming engine at 200 tiles/s using 5.25 MB scores
-    /// 38.1 — the streaming engine is 6x more memory-efficient despite
-    /// being slower in raw throughput.
+    /// Uses peak RSS — not the engine-tracked working set — so the figure
+    /// means the same thing for libviprs and libvips. Comparing the libviprs
+    /// engine-tracked bytes against the libvips process RSS is what made the
+    /// old "Nx more memory-efficient" headline apples-to-oranges (issue
+    /// #153); both sides now share the RSS basis. Returns `0` when RSS is
+    /// unavailable.
     pub fn tiles_per_second_per_mb(&self) -> f64 {
-        let mb = self.peak_memory_mb();
+        let mb = self.peak_rss_mb();
         if mb > 0.0 {
             self.tiles_per_second() / mb
         } else {
@@ -98,14 +140,14 @@ impl RunMetrics {
         }
     }
 
-    /// Resource cost: MB-seconds per tile.
+    /// Resource cost: RSS-MB-seconds per tile.
     ///
-    /// Lower is better. Measures the total resource-time consumed per tile,
-    /// penalising both high memory and long wall time. Useful for comparing
-    /// engines in environments where memory and CPU time are both billed
-    /// (containers, serverless).
+    /// Lower is better. Measures the total resource-time consumed per tile on
+    /// the common RSS basis, penalising both high memory and long wall time.
+    /// Useful for comparing engines in environments where memory and CPU time
+    /// are both billed (containers, serverless).
     pub fn resource_cost_per_tile(&self) -> f64 {
-        let mb = self.peak_memory_mb();
+        let mb = self.peak_rss_mb();
         let secs = self.wall_time.as_secs_f64();
         if self.tiles_produced > 0 {
             (mb * secs) / self.tiles_produced as f64
@@ -133,6 +175,27 @@ pub fn gradient_raster(w: u32, h: u32) -> Raster {
     Raster::new(w, h, PixelFormat::Rgb8, data).unwrap()
 }
 
+/// Create a fresh, unique temp directory for a libviprs engine's on-disk tile
+/// output. Both the libviprs engines and libvips `dzsave` write their tiles as
+/// real files under `TMPDIR/libviprs-bench/…`, so neither side gets an in-RAM
+/// sink advantage (issue #153). The directory is removed by the caller once
+/// the tiles have been counted.
+fn fs_sink_dir(label: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir()
+        .join("libviprs-bench")
+        .join(format!("engine_{}_{label}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Build the on-disk PNG sink used by every libviprs engine, rooted under a
+/// fresh temp directory. Mirrors the libvips `dzsave` output: real files, same
+/// [`BENCH_TILE_FORMAT`] codec, DeepZoom layout.
+fn engine_fs_sink(out_dir: &std::path::Path, plan: &PyramidPlan) -> FsSink {
+    FsSink::new(out_dir.join("pyramid"), plan.clone()).with_format(BENCH_TILE_FORMAT)
+}
+
 /// Run the monolithic engine and collect metrics.
 pub fn bench_monolithic(
     src: &Raster,
@@ -140,7 +203,8 @@ pub fn bench_monolithic(
     concurrency: usize,
     label: &str,
 ) -> RunMetrics {
-    let sink = MemorySink::new();
+    let out_dir = fs_sink_dir(label);
+    let sink = engine_fs_sink(&out_dir, plan);
     let observer = Arc::new(CollectingObserver::new());
     let config = EngineConfig::default().with_concurrency(concurrency);
 
@@ -152,6 +216,8 @@ pub fn bench_monolithic(
         .run()
         .unwrap();
     let wall_time = start.elapsed();
+    let peak_rss_bytes = get_peak_rss();
+    let _ = std::fs::remove_dir_all(&out_dir);
 
     RunMetrics {
         label: label.to_string(),
@@ -159,7 +225,8 @@ pub fn bench_monolithic(
         height: src.height(),
         engine: "monolithic".to_string(),
         wall_time,
-        peak_memory_bytes: result.peak_memory_bytes,
+        tracked_memory_bytes: result.peak_memory_bytes,
+        peak_rss_bytes,
         tiles_produced: result.tiles_produced,
         levels_processed: result.levels_processed,
         tiles_skipped: result.tiles_skipped,
@@ -179,7 +246,8 @@ pub fn bench_streaming(
     memory_budget_bytes: u64,
     label: &str,
 ) -> RunMetrics {
-    let sink = MemorySink::new();
+    let out_dir = fs_sink_dir(label);
+    let sink = engine_fs_sink(&out_dir, plan);
     let observer = Arc::new(CollectingObserver::new());
     let engine_config = EngineConfig::default().with_concurrency(concurrency);
     let strip_src = RasterStripSource::new(src);
@@ -193,6 +261,8 @@ pub fn bench_streaming(
         .run()
         .unwrap();
     let wall_time = start.elapsed();
+    let peak_rss_bytes = get_peak_rss();
+    let _ = std::fs::remove_dir_all(&out_dir);
 
     let strips = observer
         .events()
@@ -206,7 +276,8 @@ pub fn bench_streaming(
         height: src.height(),
         engine: "streaming".to_string(),
         wall_time,
-        peak_memory_bytes: result.peak_memory_bytes,
+        tracked_memory_bytes: result.peak_memory_bytes,
+        peak_rss_bytes,
         tiles_produced: result.tiles_produced,
         levels_processed: result.levels_processed,
         tiles_skipped: result.tiles_skipped,
@@ -226,11 +297,13 @@ pub fn bench_mapreduce(
     memory_budget_bytes: u64,
     label: &str,
 ) -> RunMetrics {
-    let sink = MemorySink::new();
+    let out_dir = fs_sink_dir(label);
+    let sink = engine_fs_sink(&out_dir, plan);
     let observer = Arc::new(CollectingObserver::new());
+    let buffer_size = 64usize;
     let engine_config = EngineConfig::default()
         .with_concurrency(tile_concurrency)
-        .with_buffer_size(64)
+        .with_buffer_size(buffer_size)
         .with_blank_tile_strategy(libviprs::BlankTileStrategy::Emit);
     let strip_src = RasterStripSource::new(src);
     let start = Instant::now();
@@ -243,6 +316,8 @@ pub fn bench_mapreduce(
         .run()
         .unwrap();
     let wall_time = start.elapsed();
+    let peak_rss_bytes = get_peak_rss();
+    let _ = std::fs::remove_dir_all(&out_dir);
 
     let events = observer.events();
     let strips = events
@@ -253,11 +328,25 @@ pub fn bench_mapreduce(
         .iter()
         .filter(|e| matches!(e, EngineEvent::BatchStarted { .. }))
         .count() as u32;
+    let strip_height = libviprs::compute_strip_height(plan, src.format(), memory_budget_bytes)
+        .unwrap_or(2 * plan.tile_size);
+    // Mirror the engine's own channel-backlog charge so the reported
+    // in-flight strip count matches what the MapReduce engine actually
+    // budgets for (libviprs `streaming_mapreduce`): the parallel emitter
+    // holds up to `buffer_size + concurrency` decoded tiles in its bounded
+    // channel. Zero when running single-threaded (`tile_concurrency == 0`).
+    let channel_bytes = if tile_concurrency > 0 {
+        let tile_bytes =
+            plan.tile_size as u64 * plan.tile_size as u64 * src.format().bytes_per_pixel() as u64;
+        (buffer_size as u64 + tile_concurrency as u64) * tile_bytes
+    } else {
+        0
+    };
     let inflight = libviprs::streaming_mapreduce::compute_inflight_strips(
         plan,
         src.format(),
-        libviprs::compute_strip_height(plan, src.format(), memory_budget_bytes)
-            .unwrap_or(2 * plan.tile_size),
+        strip_height,
+        channel_bytes,
         memory_budget_bytes,
     );
 
@@ -267,7 +356,8 @@ pub fn bench_mapreduce(
         height: src.height(),
         engine: "mapreduce".to_string(),
         wall_time,
-        peak_memory_bytes: result.peak_memory_bytes,
+        tracked_memory_bytes: result.peak_memory_bytes,
+        peak_rss_bytes,
         tiles_produced: result.tiles_produced,
         levels_processed: result.levels_processed,
         tiles_skipped: result.tiles_skipped,
@@ -347,7 +437,14 @@ pub fn bench_libvips(
             .args(["-l", "vips", "dzsave"])
             .arg(png_path)
             .arg(&dz_path)
-            .args(["--tile-size", &ts_str, "--overlap", "0", "--suffix", ".png"])
+            .args([
+                "--tile-size",
+                &ts_str,
+                "--overlap",
+                "0",
+                "--suffix",
+                BENCH_TILE_SUFFIX,
+            ])
             .env("VIPS_CONCURRENCY", &conc_str)
             .output()
     } else {
@@ -355,7 +452,14 @@ pub fn bench_libvips(
             .args(["-v", "vips", "dzsave"])
             .arg(png_path)
             .arg(&dz_path)
-            .args(["--tile-size", &ts_str, "--overlap", "0", "--suffix", ".png"])
+            .args([
+                "--tile-size",
+                &ts_str,
+                "--overlap",
+                "0",
+                "--suffix",
+                BENCH_TILE_SUFFIX,
+            ])
             .env("VIPS_CONCURRENCY", &conc_str)
             .output()
     };
@@ -443,7 +547,10 @@ pub fn bench_libvips(
         height,
         engine: "libvips".to_string(),
         wall_time,
-        peak_memory_bytes,
+        // libvips exposes no engine-internal working-set counter, so the
+        // tracked column is left at 0 and only the RSS column is populated.
+        tracked_memory_bytes: 0,
+        peak_rss_bytes: peak_memory_bytes,
         tiles_produced,
         levels_processed,
         tiles_skipped: 0,
@@ -567,7 +674,11 @@ pub fn bench_libvips_inprocess(
 
     let dz_path = out_dir.join("pyramid");
     let dz_path_c = CString::new(dz_path.to_str().unwrap()).unwrap();
-    let suffix_c = CString::new(".raw").unwrap();
+    // Same tile codec as the libviprs `FsSink` and the libvips CLI path — the
+    // in-process path historically wrote `.raw`, which meant "libvips" rows
+    // secretly skipped PNG tile encoding that both other paths paid (issue
+    // #153). Encode PNG here too so the codec is identical everywhere.
+    let suffix_c = CString::new(BENCH_TILE_SUFFIX).unwrap();
     let tile_size_c = CString::new("tile-size").unwrap();
     let overlap_c = CString::new("overlap").unwrap();
     let suffix_opt_c = CString::new("suffix").unwrap();
@@ -616,8 +727,10 @@ pub fn bench_libvips_inprocess(
         0
     };
 
-    // Measure peak RSS of current process (approximate — includes our own allocations)
-    let peak_memory_bytes = get_peak_rss();
+    // Measure peak RSS of the current process. This is a process-wide
+    // high-water mark (see `RunMetrics::peak_rss_mb`), and libvips exposes no
+    // internal working-set counter, so the tracked column stays 0.
+    let peak_rss_bytes = get_peak_rss();
 
     let _ = std::fs::remove_dir_all(&out_dir);
 
@@ -627,7 +740,8 @@ pub fn bench_libvips_inprocess(
         height: src.height(),
         engine: "libvips".to_string(),
         wall_time,
-        peak_memory_bytes,
+        tracked_memory_bytes: 0,
+        peak_rss_bytes,
         tiles_produced,
         levels_processed,
         tiles_skipped: 0,
@@ -775,18 +889,27 @@ pub fn comparison_suite(
 /// Print a comparison table to stdout.
 pub fn print_comparison_table(results: &[RunMetrics]) {
     println!(
-        "{:<24} {:<12} {:>10} {:>10} {:>8} {:>8} {:>10} {:>12}",
-        "Label", "Engine", "Time (ms)", "Mem (MB)", "Tiles", "T/s", "T/s/MB", "MB\u{00b7}s/tile"
+        "{:<24} {:<12} {:>10} {:>12} {:>10} {:>8} {:>8} {:>10} {:>12}",
+        "Label",
+        "Engine",
+        "Time (ms)",
+        "Tracked MB",
+        "RSS MB",
+        "Tiles",
+        "T/s",
+        "T/s/RSS-MB",
+        "RSS-MB\u{00b7}s/tile"
     );
-    println!("{}", "-".repeat(100));
+    println!("{}", "-".repeat(112));
 
     for r in results {
         println!(
-            "{:<24} {:<12} {:>10.1} {:>10.2} {:>8} {:>8.0} {:>10.1} {:>12.4}",
+            "{:<24} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>8} {:>8.0} {:>10.1} {:>12.4}",
             r.label,
             r.engine,
             r.wall_time_ms(),
-            r.peak_memory_mb(),
+            r.tracked_memory_mb(),
+            r.peak_rss_mb(),
             r.tiles_produced,
             r.tiles_per_second(),
             r.tiles_per_second_per_mb(),
@@ -1018,12 +1141,22 @@ pub fn generate_charts(results: &[RunMetrics], report_dir: &std::path::Path) {
         &groups,
     );
 
-    // Peak memory chart
-    let groups = extract_groups(results, |r| r.peak_memory_mb());
+    // Peak RSS chart — the cross-engine-comparable memory basis.
+    let groups = extract_groups(results, |r| r.peak_rss_mb());
     draw_grouped_bar_chart(
         &report_dir.join("chart_peak_memory.svg"),
-        "Peak Memory (lower is better)",
-        "Memory (MB)",
+        "Peak RSS (lower is better)",
+        "Peak RSS (MB)",
+        &groups,
+    );
+
+    // Engine-tracked working set — a libviprs-only, per-run figure kept in a
+    // separate chart so it is never confused with the RSS basis above.
+    let groups = extract_groups(results, |r| r.tracked_memory_mb());
+    draw_grouped_bar_chart(
+        &report_dir.join("chart_tracked_memory.svg"),
+        "Engine-Tracked Working Set (libviprs engines; lower is better)",
+        "Tracked (MB)",
         &groups,
     );
 
@@ -1040,8 +1173,8 @@ pub fn generate_charts(results: &[RunMetrics], report_dir: &std::path::Path) {
     let groups = extract_groups(results, |r| r.tiles_per_second_per_mb());
     draw_grouped_bar_chart(
         &report_dir.join("chart_efficiency.svg"),
-        "Memory Efficiency — Tiles/s per MB (higher is better)",
-        "Tiles/s/MB",
+        "Memory Efficiency — Tiles/s per RSS-MB (higher is better)",
+        "Tiles/s/RSS-MB",
         &groups,
     );
 
@@ -1049,8 +1182,8 @@ pub fn generate_charts(results: &[RunMetrics], report_dir: &std::path::Path) {
     let groups = extract_groups(results, |r| r.resource_cost_per_tile());
     draw_grouped_bar_chart(
         &report_dir.join("chart_resource_cost.svg"),
-        "Resource Cost — MB\u{00b7}s per Tile (lower is better)",
-        "MB\u{00b7}s / tile",
+        "Resource Cost — RSS-MB\u{00b7}s per Tile (lower is better)",
+        "RSS-MB\u{00b7}s / tile",
         &groups,
     );
 }
@@ -1089,7 +1222,7 @@ pub fn generate_history_chart(
             let pt = Point {
                 version: snap.version.clone(),
                 wall_time_ms: run.wall_time_ms(),
-                peak_memory_mb: run.peak_memory_mb(),
+                peak_memory_mb: run.peak_rss_mb(),
             };
             match run.engine.as_str() {
                 "libvips" => vips_pts.push(pt),
@@ -1201,7 +1334,7 @@ pub fn generate_history_chart(
 
     let mut chart = ChartBuilder::on(&root)
         .caption(
-            format!("Peak Memory History — {w}x{h} c{concurrency}"),
+            format!("Peak RSS History — {w}x{h} c{concurrency}"),
             ("sans-serif", 16).into_font(),
         )
         .margin(10)
@@ -1270,10 +1403,17 @@ pub fn print_savings_summary(results: &[RunMetrics]) {
 
     println!();
     println!(
-        "{:<16} {:<12} {:>10} {:>10} {:>10} {:>10} {:>12}",
-        "Config", "Engine", "Time (ms)", "Mem (MB)", "T/s", "T/s/MB", "MB\u{00b7}s/tile",
+        "{:<16} {:<12} {:>10} {:>12} {:>10} {:>10} {:>10} {:>12}",
+        "Config",
+        "Engine",
+        "Time (ms)",
+        "Tracked MB",
+        "RSS MB",
+        "T/s",
+        "T/s/RSS-MB",
+        "RSS-MB\u{00b7}s/tile",
     );
-    println!("{}", "-".repeat(86));
+    println!("{}", "-".repeat(98));
 
     for group in &groups {
         let config = format!(
@@ -1283,11 +1423,12 @@ pub fn print_savings_summary(results: &[RunMetrics]) {
         for (i, r) in group.iter().enumerate() {
             let label = if i == 0 { &config } else { "" };
             println!(
-                "{:<16} {:<12} {:>10.1} {:>10.2} {:>10.0} {:>10.1} {:>12.4}",
+                "{:<16} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>10.0} {:>10.1} {:>12.4}",
                 label,
                 r.engine,
                 r.wall_time_ms(),
-                r.peak_memory_mb(),
+                r.tracked_memory_mb(),
+                r.peak_rss_mb(),
                 r.tiles_per_second(),
                 r.tiles_per_second_per_mb(),
                 r.resource_cost_per_tile(),

--- a/src/report.rs
+++ b/src/report.rs
@@ -72,18 +72,27 @@ fn main() {
     ));
 
     txt.push_str(&format!(
-        "{:<24} {:<12} {:>10} {:>10} {:>8} {:>8} {:>10} {:>12}\n",
-        "Label", "Engine", "Time (ms)", "Mem (MB)", "Tiles", "T/s", "T/s/MB", "MB\u{00b7}s/tile"
+        "{:<24} {:<12} {:>10} {:>12} {:>10} {:>8} {:>8} {:>10} {:>12}\n",
+        "Label",
+        "Engine",
+        "Time (ms)",
+        "Tracked MB",
+        "RSS MB",
+        "Tiles",
+        "T/s",
+        "T/s/RSS-MB",
+        "RSS-MB\u{00b7}s/tile"
     ));
-    txt.push_str(&format!("{}\n", "-".repeat(100)));
+    txt.push_str(&format!("{}\n", "-".repeat(112)));
 
     for r in &results {
         txt.push_str(&format!(
-            "{:<24} {:<12} {:>10.1} {:>10.2} {:>8} {:>8.0} {:>10.1} {:>12.4}\n",
+            "{:<24} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>8} {:>8.0} {:>10.1} {:>12.4}\n",
             r.label,
             r.engine,
             r.wall_time_ms(),
-            r.peak_memory_mb(),
+            r.tracked_memory_mb(),
+            r.peak_rss_mb(),
             r.tiles_produced,
             r.tiles_per_second(),
             r.tiles_per_second_per_mb(),
@@ -99,6 +108,7 @@ fn main() {
     println!("Charts written:");
     println!("  {}", report_dir.join("chart_wall_time.svg").display());
     println!("  {}", report_dir.join("chart_peak_memory.svg").display());
+    println!("  {}", report_dir.join("chart_tracked_memory.svg").display());
     println!("  {}", report_dir.join("chart_throughput.svg").display());
     println!("  {}", report_dir.join("chart_efficiency.svg").display());
     println!("  {}", report_dir.join("chart_resource_cost.svg").display());

--- a/src/scalability.rs
+++ b/src/scalability.rs
@@ -19,10 +19,31 @@ use serde::{Deserialize, Serialize};
 
 use libviprs::streaming::BudgetPolicy;
 use libviprs::{
-    EngineBuilder, EngineConfig, EngineKind, Layout, MemorySink, PyramidPlanner, Raster,
-    RasterStripSource,
+    EngineBuilder, EngineConfig, EngineKind, FsSink, Layout, PyramidPlanner, Raster,
+    RasterStripSource, TileFormat,
 };
 use libviprs_bench::{bench_libvips, gradient_raster, vips_available, write_temp_png};
+
+/// Peak RSS of the current process in bytes. Mirrors the RSS basis the
+/// libvips paths report so the scalability charts compare like-for-like
+/// memory (issue #153). `ru_maxrss` is a process-wide high-water mark; see
+/// the note in `libviprs_bench::RunMetrics::peak_rss_mb`.
+fn process_peak_rss() -> u64 {
+    use std::mem::MaybeUninit;
+    let mut rusage = MaybeUninit::<libc::rusage>::uninit();
+    let ret = unsafe { libc::getrusage(libc::RUSAGE_SELF, rusage.as_mut_ptr()) };
+    if ret != 0 {
+        return 0;
+    }
+    let rusage = unsafe { rusage.assume_init() };
+    if cfg!(target_os = "macos") {
+        // macOS reports ru_maxrss in bytes.
+        rusage.ru_maxrss as u64
+    } else {
+        // Linux reports ru_maxrss in kilobytes.
+        rusage.ru_maxrss as u64 * 1024
+    }
+}
 
 const TILE_SIZE: u32 = 256;
 /// Floor on the streaming engine's memory budget. Keeps small images in
@@ -58,36 +79,70 @@ struct ScalabilityPoint {
     megapixels: f64,
     engine: String,
     wall_time_ms: f64,
-    peak_memory_mb: f64,
+    /// Engine-tracked working set (libviprs engines; 0 for libvips). Kept in a
+    /// separate field from `peak_rss_mb` so the two memory bases are never
+    /// conflated (issue #153).
+    tracked_memory_mb: f64,
+    /// Process/child peak RSS — the cross-engine-comparable memory basis.
+    peak_rss_mb: f64,
     tiles_produced: u64,
     tiles_per_second: f64,
+    /// Tiles/s per RSS-MB (common basis).
     tiles_per_second_per_mb: f64,
+    /// RSS-MB-seconds per tile (common basis).
     resource_cost: f64,
 }
 
-fn run_monolithic(src: &Raster, tile_size: u32) -> (std::time::Duration, u64, u64) {
+/// A libviprs engine run's measurements: wall time, engine-tracked working
+/// set, process peak RSS, and tile count.
+struct EngineRun {
+    dur: std::time::Duration,
+    tracked_bytes: u64,
+    rss_bytes: u64,
+    tiles: u64,
+}
+
+/// Fresh temp directory for on-disk tile output. The libviprs engines write
+/// real PNG tiles here just like libvips `dzsave`, so neither side gets an
+/// in-RAM sink advantage (issue #153). Removed by the caller once counted.
+fn sink_dir(label: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir()
+        .join("libviprs-bench")
+        .join(format!("scal_{}_{label}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run_monolithic(src: &Raster, tile_size: u32) -> EngineRun {
     let planner =
         PyramidPlanner::new(src.width(), src.height(), tile_size, 0, Layout::DeepZoom).unwrap();
     let plan = planner.plan();
-    let sink = MemorySink::new();
+    let out_dir = sink_dir("mono");
+    let sink = FsSink::new(out_dir.join("pyramid"), plan.clone()).with_format(TileFormat::Png);
     let start = Instant::now();
     let result = EngineBuilder::new(src, plan, &sink)
         .with_engine(EngineKind::Monolithic)
         .with_config(EngineConfig::default())
         .run()
         .unwrap();
-    (
-        start.elapsed(),
-        result.peak_memory_bytes,
-        result.tiles_produced,
-    )
+    let dur = start.elapsed();
+    let rss_bytes = process_peak_rss();
+    let _ = std::fs::remove_dir_all(&out_dir);
+    EngineRun {
+        dur,
+        tracked_bytes: result.peak_memory_bytes,
+        rss_bytes,
+        tiles: result.tiles_produced,
+    }
 }
 
-fn run_streaming(src: &Raster, tile_size: u32, budget: u64) -> (std::time::Duration, u64, u64) {
+fn run_streaming(src: &Raster, tile_size: u32, budget: u64) -> EngineRun {
     let planner =
         PyramidPlanner::new(src.width(), src.height(), tile_size, 0, Layout::DeepZoom).unwrap();
     let plan = planner.plan();
-    let sink = MemorySink::new();
+    let out_dir = sink_dir("stream");
+    let sink = FsSink::new(out_dir.join("pyramid"), plan.clone()).with_format(TileFormat::Png);
     let strip_src = RasterStripSource::new(src);
     let start = Instant::now();
     let result = EngineBuilder::new(strip_src, plan, &sink)
@@ -97,18 +152,23 @@ fn run_streaming(src: &Raster, tile_size: u32, budget: u64) -> (std::time::Durat
         .with_budget_policy(BudgetPolicy::Error)
         .run()
         .unwrap();
-    (
-        start.elapsed(),
-        result.peak_memory_bytes,
-        result.tiles_produced,
-    )
+    let dur = start.elapsed();
+    let rss_bytes = process_peak_rss();
+    let _ = std::fs::remove_dir_all(&out_dir);
+    EngineRun {
+        dur,
+        tracked_bytes: result.peak_memory_bytes,
+        rss_bytes,
+        tiles: result.tiles_produced,
+    }
 }
 
-fn run_mapreduce(src: &Raster, tile_size: u32, budget: u64) -> (std::time::Duration, u64, u64) {
+fn run_mapreduce(src: &Raster, tile_size: u32, budget: u64) -> EngineRun {
     let planner =
         PyramidPlanner::new(src.width(), src.height(), tile_size, 0, Layout::DeepZoom).unwrap();
     let plan = planner.plan();
-    let sink = MemorySink::new();
+    let out_dir = sink_dir("mr");
+    let sink = FsSink::new(out_dir.join("pyramid"), plan.clone()).with_format(TileFormat::Png);
     let strip_src = RasterStripSource::new(src);
     let start = Instant::now();
     let result = EngineBuilder::new(strip_src, plan, &sink)
@@ -118,11 +178,15 @@ fn run_mapreduce(src: &Raster, tile_size: u32, budget: u64) -> (std::time::Durat
         .with_budget_policy(BudgetPolicy::Error)
         .run()
         .unwrap();
-    (
-        start.elapsed(),
-        result.peak_memory_bytes,
-        result.tiles_produced,
-    )
+    let dur = start.elapsed();
+    let rss_bytes = process_peak_rss();
+    let _ = std::fs::remove_dir_all(&out_dir);
+    EngineRun {
+        dur,
+        tracked_bytes: result.peak_memory_bytes,
+        rss_bytes,
+        tiles: result.tiles_produced,
+    }
 }
 
 fn to_point(
@@ -130,17 +194,21 @@ fn to_point(
     h: u32,
     engine: &str,
     dur: std::time::Duration,
-    peak: u64,
+    tracked_bytes: u64,
+    rss_bytes: u64,
     tiles: u64,
 ) -> ScalabilityPoint {
     let mp = w as f64 * h as f64 / 1_000_000.0;
     let secs = dur.as_secs_f64();
     let ms = secs * 1000.0;
-    let peak_mb = peak as f64 / (1024.0 * 1024.0);
+    let tracked_mb = tracked_bytes as f64 / (1024.0 * 1024.0);
+    let rss_mb = rss_bytes as f64 / (1024.0 * 1024.0);
     let tps = if secs > 0.0 { tiles as f64 / secs } else { 0.0 };
-    let tps_mb = if peak_mb > 0.0 { tps / peak_mb } else { 0.0 };
+    // Efficiency and resource-cost use the common RSS basis so every engine's
+    // number means the same thing (issue #153).
+    let tps_mb = if rss_mb > 0.0 { tps / rss_mb } else { 0.0 };
     let cost = if tiles > 0 {
-        (peak_mb * secs) / tiles as f64
+        (rss_mb * secs) / tiles as f64
     } else {
         0.0
     };
@@ -151,7 +219,8 @@ fn to_point(
         megapixels: mp,
         engine: engine.to_string(),
         wall_time_ms: ms,
-        peak_memory_mb: peak_mb,
+        tracked_memory_mb: tracked_mb,
+        peak_rss_mb: rss_mb,
         tiles_produced: tiles,
         tiles_per_second: tps,
         tiles_per_second_per_mb: tps_mb,
@@ -276,7 +345,7 @@ fn render_charts(
                 (
                     p.megapixels,
                     p.wall_time_ms,
-                    p.peak_memory_mb,
+                    p.peak_rss_mb,
                     p.tiles_per_second,
                     p.tiles_per_second_per_mb,
                     p.resource_cost,
@@ -310,8 +379,8 @@ fn render_charts(
         ),
         (
             "scalability_peak_memory.svg",
-            "Peak Memory Scalability — 43551_California_South.pdf",
-            "Peak Memory (MB)",
+            "Peak RSS Scalability — 43551_California_South.pdf",
+            "Peak RSS (MB)",
             2,
         ),
         (
@@ -506,17 +575,14 @@ fn main() {
         #[cfg(feature = "libvips")]
         {
             if let Some(r) = libviprs_bench::bench_libvips_inprocess(&src, TILE_SIZE, 1, "vips") {
-                print!(
-                    "vips={:.0}ms/{:.1}MB  ",
-                    r.wall_time_ms(),
-                    r.peak_memory_mb(),
-                );
+                print!("vips={:.0}ms/{:.1}MB(rss)  ", r.wall_time_ms(), r.peak_rss_mb());
                 all_points.push(to_point(
                     w,
                     h,
                     "libvips",
                     r.wall_time,
-                    r.peak_memory_bytes,
+                    r.tracked_memory_bytes,
+                    r.peak_rss_bytes,
                     r.tiles_produced,
                 ));
                 vips_done = true;
@@ -525,17 +591,14 @@ fn main() {
         if !vips_done && has_vips {
             let png_path = write_temp_png(&src);
             if let Some(r) = bench_libvips(&png_path, w, h, TILE_SIZE, 1, "vips") {
-                print!(
-                    "vips={:.0}ms/{:.1}MB  ",
-                    r.wall_time_ms(),
-                    r.peak_memory_mb(),
-                );
+                print!("vips={:.0}ms/{:.1}MB(rss)  ", r.wall_time_ms(), r.peak_rss_mb());
                 all_points.push(to_point(
                     w,
                     h,
                     "libvips",
                     r.wall_time,
-                    r.peak_memory_bytes,
+                    r.tracked_memory_bytes,
+                    r.peak_rss_bytes,
                     r.tiles_produced,
                 ));
             }
@@ -543,35 +606,59 @@ fn main() {
         }
 
         // Monolithic
-        let (dur, peak, tiles) = run_monolithic(&src, TILE_SIZE);
+        let run = run_monolithic(&src, TILE_SIZE);
         print!(
-            "mono={:.0}ms/{:.1}MB  ",
-            dur.as_secs_f64() * 1000.0,
-            peak as f64 / (1024.0 * 1024.0),
+            "mono={:.0}ms/{:.1}MB(trk)  ",
+            run.dur.as_secs_f64() * 1000.0,
+            run.tracked_bytes as f64 / (1024.0 * 1024.0),
         );
-        all_points.push(to_point(w, h, "monolithic", dur, peak, tiles));
+        all_points.push(to_point(
+            w,
+            h,
+            "monolithic",
+            run.dur,
+            run.tracked_bytes,
+            run.rss_bytes,
+            run.tiles,
+        ));
 
         // Streaming + MapReduce share a budget chosen per-width so the
         // tile-aligned minimum strip always fits.
         let budget = streaming_budget_for(w, TILE_SIZE);
 
         // Streaming
-        let (dur, peak, tiles) = run_streaming(&src, TILE_SIZE, budget);
+        let run = run_streaming(&src, TILE_SIZE, budget);
         print!(
-            "stream={:.0}ms/{:.1}MB  ",
-            dur.as_secs_f64() * 1000.0,
-            peak as f64 / (1024.0 * 1024.0),
+            "stream={:.0}ms/{:.1}MB(trk)  ",
+            run.dur.as_secs_f64() * 1000.0,
+            run.tracked_bytes as f64 / (1024.0 * 1024.0),
         );
-        all_points.push(to_point(w, h, "streaming", dur, peak, tiles));
+        all_points.push(to_point(
+            w,
+            h,
+            "streaming",
+            run.dur,
+            run.tracked_bytes,
+            run.rss_bytes,
+            run.tiles,
+        ));
 
         // MapReduce
-        let (dur, peak, tiles) = run_mapreduce(&src, TILE_SIZE, budget);
+        let run = run_mapreduce(&src, TILE_SIZE, budget);
         println!(
-            "mr={:.0}ms/{:.1}MB",
-            dur.as_secs_f64() * 1000.0,
-            peak as f64 / (1024.0 * 1024.0),
+            "mr={:.0}ms/{:.1}MB(trk)",
+            run.dur.as_secs_f64() * 1000.0,
+            run.tracked_bytes as f64 / (1024.0 * 1024.0),
         );
-        all_points.push(to_point(w, h, "mapreduce", dur, peak, tiles));
+        all_points.push(to_point(
+            w,
+            h,
+            "mapreduce",
+            run.dur,
+            run.tracked_bytes,
+            run.rss_bytes,
+            run.tiles,
+        ));
     }
 
     // --- Generate charts ---
@@ -585,17 +672,25 @@ fn main() {
     // Print summary table
     println!();
     println!(
-        "{:<14} {:<12} {:>10} {:>10} {:>8} {:>10} {:>12}",
-        "Size", "Engine", "Time (ms)", "Mem (MB)", "Tiles", "T/s/MB", "MB\u{00b7}s/tile",
+        "{:<14} {:<12} {:>10} {:>12} {:>10} {:>8} {:>12} {:>14}",
+        "Size",
+        "Engine",
+        "Time (ms)",
+        "Tracked MB",
+        "RSS MB",
+        "Tiles",
+        "T/s/RSS-MB",
+        "RSS-MB\u{00b7}s/tile",
     );
-    println!("{}", "-".repeat(80));
+    println!("{}", "-".repeat(92));
     for p in &all_points {
         println!(
-            "{:<14} {:<12} {:>10.1} {:>10.2} {:>8} {:>10.1} {:>12.4}",
+            "{:<14} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>8} {:>12.1} {:>14.4}",
             format!("{}x{}", p.width, p.height),
             p.engine,
             p.wall_time_ms,
-            p.peak_memory_mb,
+            p.tracked_memory_mb,
+            p.peak_rss_mb,
             p.tiles_produced,
             p.tiles_per_second_per_mb,
             p.resource_cost,
@@ -623,8 +718,8 @@ fn main() {
             largest.0, largest.1, largest_mp,
         );
         println!(
-            "  Peak memory: {:.1} MB — dominated by the full canvas allocation",
-            mono.peak_memory_mb,
+            "  Tracked working set: {:.1} MB — dominated by the full canvas allocation",
+            mono.tracked_memory_mb,
         );
         println!(
             "  The source raster ({:.1} MB) is cloned into a canvas-sized buffer.",
@@ -652,8 +747,8 @@ fn main() {
             streaming_budget_for(largest.0, TILE_SIZE) as f64 / (1024.0 * 1024.0),
         );
         println!(
-            "  Peak memory: {:.1} MB — bounded by strip height, not canvas area.",
-            stream.peak_memory_mb,
+            "  Tracked working set: {:.1} MB — bounded by strip height, not canvas area.",
+            stream.tracked_memory_mb,
         );
         println!("  The engine holds: current strip + accumulator at each pyramid level",);
         println!("  (geometric series: strip + strip/4 + strip/16 + ...). Strip height is",);
@@ -675,8 +770,8 @@ fn main() {
             streaming_budget_for(largest.0, TILE_SIZE) as f64 / (1024.0 * 1024.0),
         );
         println!(
-            "  Peak memory: {:.1} MB — same strip-bounded model as streaming.",
-            mr.peak_memory_mb,
+            "  Tracked working set: {:.1} MB — same strip-bounded model as streaming.",
+            mr.tracked_memory_mb,
         );
         println!("  With K in-flight strips, peak = K × strip_cost + accumulator chain.",);
         println!("  The budget was too small for K>1 in-flight strips at this image width,",);
@@ -696,7 +791,7 @@ fn main() {
         );
         println!(
             "  Peak RSS: {:.1} MB — libvips uses a demand-driven pipeline where pixels",
-            vips.peak_memory_mb,
+            vips.peak_rss_mb,
         );
         println!("  are computed on demand per-region (O(tile_size²) working set). The RSS",);
         println!("  measured here includes the OS-level allocation footprint, which is higher",);
@@ -719,7 +814,7 @@ fn main() {
             .iter()
             .find(|p| p.width == largest.0 && p.engine == *engine);
         if let (Some(s), Some(l)) = (small, large) {
-            let mem_scale = l.peak_memory_mb / s.peak_memory_mb.max(0.01);
+            let mem_scale = l.peak_rss_mb / s.peak_rss_mb.max(0.01);
             let time_scale = l.wall_time_ms / s.wall_time_ms.max(0.01);
             println!(
                 "  {:<12} image area {:.0}x larger → memory {:.1}x, time {:.1}x",

--- a/tests/vips_ffi.rs
+++ b/tests/vips_ffi.rs
@@ -12,6 +12,46 @@
 //!    able to outlive the borrow it aliases. The FFI wrapper must tie the
 //!    image handle's lifetime to the borrowed raster.
 
+/// Cross-engine fairness guard (#153): the shared bench functions must not
+/// give the libviprs engines an in-RAM sink advantage, and both sides must
+/// encode the same tile codec.
+///
+/// This is a cheap source-level CI check that fails the moment either half of
+/// the fairness fix regresses — without needing libvips linked in.
+#[test]
+fn cross_engine_comparison_is_structurally_fair() {
+    let source = include_str!("../src/lib.rs");
+
+    // 1. Sink medium: the libviprs engine bench functions must write real
+    //    tiles through `FsSink`, not collect them in a `MemorySink`. The old
+    //    code let libviprs skip all filesystem I/O that libvips paid.
+    assert!(
+        source.contains("FsSink::new") || source.contains("engine_fs_sink"),
+        "libviprs engine benches must write to an on-disk FsSink (see #153)"
+    );
+    assert!(
+        !source.contains("MemorySink"),
+        "src/lib.rs still uses a MemorySink for the cross-engine benches — \
+         that hands the libviprs engines an in-RAM sink advantage libvips \
+         never gets (see #153)"
+    );
+
+    // 2. Codec: both the in-process and CLI libvips paths, and the libviprs
+    //    FsSink, must encode the same format. The in-process path used to
+    //    write `.raw` tiles while the CLI wrote `.png`, both reported as
+    //    engine "libvips".
+    assert!(
+        !source.contains("\".raw\""),
+        "src/lib.rs still writes `.raw` tiles somewhere — the libvips \
+         in-process path must use the same codec as everyone else (see #153)"
+    );
+    assert!(
+        source.contains("BENCH_TILE_SUFFIX") && source.contains("BENCH_TILE_FORMAT"),
+        "both engines must route through the shared BENCH_TILE_* codec \
+         constants so the tile format is not a hidden variable (see #153)"
+    );
+}
+
 /// The libvips app global must not be declared `static mut`.
 ///
 /// Fails on the pre-fix code (`static mut APP: Option<VipsApp>`), passes
@@ -45,4 +85,46 @@ fn vips_inprocess_produces_tiles() {
         "expected dzsave to produce tiles, got {}",
         metrics.tiles_produced
     );
+}
+
+/// End-to-end fairness (#153): a libviprs engine and libvips run on the same
+/// raster and DeepZoom plan must both produce tiles (both now writing PNG
+/// tiles to a real filesystem sink), and the two memory bases must be
+/// reported in their own labelled fields — never conflated.
+#[cfg(feature = "libvips")]
+#[test]
+fn engines_share_sink_and_report_separate_memory_columns() {
+    let raster = libviprs_bench::gradient_raster(512, 512);
+    let planner =
+        libviprs::PyramidPlanner::new(512, 512, 256, 0, libviprs::Layout::DeepZoom).unwrap();
+    let plan = planner.plan();
+
+    let mono = libviprs_bench::bench_monolithic(&raster, &plan, 1, "fair_mono");
+    let vips = libviprs_bench::bench_libvips_inprocess(&raster, 256, 1, "fair_vips")
+        .expect("libvips in-process bench returned None");
+
+    // Both engines actually produce a pyramid on disk under identical input.
+    assert!(mono.tiles_produced > 0, "monolithic produced no tiles");
+    assert!(vips.tiles_produced > 0, "libvips produced no tiles");
+
+    // Memory columns are separate and correctly attributed:
+    //  - the libviprs engine exposes an engine-tracked working set,
+    //  - libvips exposes none (tracked == 0) and only an RSS figure.
+    assert!(
+        mono.tracked_memory_bytes > 0,
+        "libviprs engine should report a non-zero tracked working set"
+    );
+    assert_eq!(
+        vips.tracked_memory_bytes, 0,
+        "libvips has no engine-tracked counter; its tracked column must be 0 \
+         rather than borrowing an unrelated basis (see #153)"
+    );
+    assert!(
+        vips.peak_rss_bytes > 0,
+        "libvips must report a peak RSS figure"
+    );
+
+    // The codec constant both sides encode is PNG.
+    assert_eq!(libviprs_bench::BENCH_TILE_FORMAT, libviprs::TileFormat::Png);
+    assert_eq!(libviprs_bench::BENCH_TILE_SUFFIX, ".png");
 }


### PR DESCRIPTION
## Problem

The flagship libviprs-vs-libvips comparison was structurally unfair along four axes (issue #153):

1. **Sink** — libviprs engines wrote to an in-RAM `MemorySink` while libvips paid real filesystem writes.
2. **Codec** — the in-process libvips FFI path encoded `.raw` tiles while the CLI encoded `.png`, both reported as engine `"libvips"`.
3. **Metric** — libviprs "memory" was engine-tracked raster bytes; libvips "memory" was whole-process peak RSS; the two fed the "Nx more memory-efficient" headline as if comparable.
4. **Environment** — `rust:latest`, unpinned `libvips-dev`, and `latest` PDFium floated between runs.

## Fix

- **Same sink + codec on both sides.** Every engine — the three libviprs engines and libvips `dzsave` — now writes PNG tiles through an on-disk sink under the same DeepZoom layout. A single `BENCH_TILE_*` codec constant drives the libviprs `FsSink`, the CLI `--suffix`, and the in-process dzsave suffix (both `src/lib.rs` report/suite path and the `scalability` sweep).
- **Labelled, comparable memory columns.** `RunMetrics` now carries `tracked_memory_bytes` (engine working set; `0` for libvips) and `peak_rss_bytes` (measured the same way for every engine). Cross-engine efficiency / resource-cost use the common RSS basis; peak RSS is now measured for the libviprs engines too. Tables, charts, and the cross-version report surface the two columns separately.
- **Pinned environment.** `rust:latest` → `rust:1.89-bookworm`; `libvips-dev`/`libvips-tools` pinned to the exact bookworm version; PDFium `latest` → a concrete release tag; the Debian download stage pinned to a dated snapshot.

## Tests / verification

- New `tests/vips_ffi.rs::cross_engine_comparison_is_structurally_fair` — source-level guard that fails if the `MemorySink` advantage or the `.raw` codec mismatch ever returns.
- New feature-gated `engines_share_sink_and_report_separate_memory_columns` — end-to-end: a libviprs engine and libvips run on the same raster both produce tiles, and the memory columns are separate and correctly attributed.
- Verified locally: `cargo check` for the default/libvips/pdfium/polars feature cells, `cargo clippy --features libvips`, and `cargo test --lib --tests --doc --features libvips` (all green). The `scalability` binary runs end-to-end with libvips 8.18, showing `(rss)` for libvips and `(trk)` for the libviprs engines in separate columns.

Also passes the channel-backlog argument the MapReduce engine's `compute_inflight_strips` now requires, so the harness builds against current libviprs.

Closes #153