### PR TITLE
Fix bench history: correct crate version + fail soft on corrupt history

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,81 @@
+//! Capture the *measured* core crate's identity at build time.
+//!
+//! The bench history keys every snapshot on the version of the
+//! `libviprs` engine it measured, not on this harness's own version.
+//! Cargo only exposes `CARGO_PKG_VERSION` for the crate being compiled,
+//! which here is `libviprs-bench` (a different version from core), so I
+//! read the sibling path dependency's manifest directly and stamp two
+//! compile-time env vars the library reads back:
+//!
+//!   * `LIBVIPRS_CORE_VERSION` — the `[package] version` from
+//!     `../libviprs/Cargo.toml`.
+//!   * `LIBVIPRS_CORE_GIT_SHA` — the short git SHA of that checkout, or
+//!     `unknown` when git is unavailable (git-less tarball, no repo).
+//!
+//! Both always get emitted (with `unknown` fallbacks) so the library can
+//! read them unconditionally without risking a compile error.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Path to the measured core crate, relative to this crate's manifest.
+/// It is a Cargo path dependency (`libviprs = { path = "../libviprs" }`),
+/// so if this crate compiles at all the directory is present.
+const CORE_DIR: &str = "../libviprs";
+
+fn main() {
+    let core_dir = Path::new(CORE_DIR);
+    let manifest = core_dir.join("Cargo.toml");
+
+    let version = read_package_version(&manifest).unwrap_or_else(|| "unknown".to_string());
+    let sha = git_short_sha(core_dir).unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=LIBVIPRS_CORE_VERSION={version}");
+    println!("cargo:rustc-env=LIBVIPRS_CORE_GIT_SHA={sha}");
+
+    // Re-run when the core manifest changes so the stamped version keeps
+    // pace with a core version bump without a manual clean.
+    println!("cargo:rerun-if-changed={}", manifest.display());
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+/// Extract the first `version = "..."` from the `[package]` section of a
+/// Cargo manifest. I keep this to a small hand scan rather than pulling
+/// in a TOML parser as a build dependency: the `[package] version` line
+/// is stable and appears before any other table.
+fn read_package_version(manifest: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(manifest).ok()?;
+    let mut in_package = false;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            in_package = line == "[package]";
+            continue;
+        }
+        if in_package {
+            if let Some(rest) = line.strip_prefix("version") {
+                let rest = rest.trim_start();
+                if let Some(rest) = rest.strip_prefix('=') {
+                    return Some(rest.trim().trim_matches('"').to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Short git SHA of the core checkout, or `None` if git can't resolve it
+/// (no repository, git not installed, detached tarball).
+fn git_short_sha(core_dir: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(core_dir)
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if sha.is_empty() { None } else { Some(sha) }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,16 @@ pub const BENCH_TILE_SUFFIX: &str = ".png";
 /// tracked across releases. Each run appends one entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchmarkSnapshot {
-    /// libviprs version (from Cargo.toml).
+    /// Version of the *measured* `libviprs` core crate, captured at
+    /// build time from `../libviprs/Cargo.toml`. This is the engine the
+    /// numbers describe, not this harness's own `CARGO_PKG_VERSION`
+    /// (the two drift, e.g. bench 0.3.0 while core is 0.3.1).
     pub version: String,
+    /// Short git SHA of the measured core crate's checkout, or
+    /// `"unknown"` when git could not resolve it at build time. Defaults
+    /// to empty for history files written before this field existed.
+    #[serde(default)]
+    pub git_sha: String,
     /// ISO 8601 timestamp of the run.
     pub timestamp: String,
     /// Tile size used.
@@ -932,12 +940,38 @@ pub fn grouped_results(results: &[RunMetrics]) -> Vec<Vec<&RunMetrics>> {
     map.into_values().collect()
 }
 
-/// Load benchmark history from disk, or return an empty vec.
-pub fn load_history(path: &std::path::Path) -> Vec<BenchmarkSnapshot> {
+/// Load benchmark history from disk.
+///
+/// A missing file is not an error: there's simply no history yet, so I
+/// return an empty vec. A file that exists but fails to parse *is* an
+/// error, surfaced to the caller instead of swallowed. The previous
+/// `unwrap_or_default()` turned a corrupt file into an empty vec, and
+/// the very next [`save_history`] then overwrote the file with only the
+/// current run, silently destroying every accumulated snapshot. Callers
+/// must treat `Err` as "leave the existing file untouched".
+pub fn load_history(path: &std::path::Path) -> Result<Vec<BenchmarkSnapshot>, String> {
     match std::fs::read_to_string(path) {
-        Ok(json) => serde_json::from_str(&json).unwrap_or_default(),
-        Err(_) => Vec::new(),
+        Ok(json) => serde_json::from_str(&json)
+            .map_err(|e| format!("couldn't parse benchmark history {}: {e}", path.display())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(e) => Err(format!(
+            "couldn't read benchmark history {}: {e}",
+            path.display()
+        )),
     }
+}
+
+/// Version of the *measured* `libviprs` core crate, captured at build
+/// time from `../libviprs/Cargo.toml` (see `build.rs`). Falls back to
+/// `"unknown"` if the build script could not stamp it.
+pub fn core_version() -> &'static str {
+    option_env!("LIBVIPRS_CORE_VERSION").unwrap_or("unknown")
+}
+
+/// Short git SHA of the measured core crate's checkout, captured at
+/// build time. `"unknown"` when git could not resolve it.
+pub fn core_git_sha() -> &'static str {
+    option_env!("LIBVIPRS_CORE_GIT_SHA").unwrap_or("unknown")
 }
 
 /// Append a snapshot to the history file.
@@ -953,7 +987,8 @@ pub fn create_snapshot(
     memory_budget_bytes: u64,
 ) -> BenchmarkSnapshot {
     BenchmarkSnapshot {
-        version: env!("CARGO_PKG_VERSION").to_string(),
+        version: core_version().to_string(),
+        git_sha: core_git_sha().to_string(),
         timestamp: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         tile_size,
         memory_budget_bytes,
@@ -1435,5 +1470,79 @@ pub fn print_savings_summary(results: &[RunMetrics]) {
             );
         }
         println!();
+    }
+}
+
+#[cfg(test)]
+mod history_tests {
+    use super::*;
+
+    /// A unique scratch path under the OS temp dir, no external crate.
+    fn scratch_path(tag: &str) -> std::path::PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("libviprs_bench_{tag}_{nanos}.json"))
+    }
+
+    #[test]
+    fn missing_history_file_is_empty_not_error() {
+        let path = scratch_path("missing");
+        // Ensure it really does not exist.
+        let _ = std::fs::remove_file(&path);
+        let loaded = load_history(&path).expect("missing file must be Ok(empty)");
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn valid_history_round_trips() {
+        let path = scratch_path("valid");
+        let history = vec![create_snapshot(Vec::new(), 256, 1_000_000)];
+        save_history(&path, &history);
+
+        let loaded = load_history(&path).expect("valid file must parse");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].version, history[0].version);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn corrupt_history_is_reported_and_left_intact() {
+        let path = scratch_path("corrupt");
+        // A prior run's accumulated history that happens to be corrupt.
+        let corrupt = "[ { \"version\": \"0.3.1\", not-valid-json ]";
+        std::fs::write(&path, corrupt).unwrap();
+
+        // load_history must surface the error rather than silently
+        // returning an empty vec (which the caller would then persist,
+        // wiping the file).
+        let result = load_history(&path);
+        assert!(
+            result.is_err(),
+            "corrupt history must be an error, got {result:?}"
+        );
+
+        // And critically, load_history does not itself mutate the file:
+        // the accumulated (if unreadable) history is preserved on disk
+        // for repair instead of being discarded.
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(after, corrupt);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn snapshot_records_measured_core_version_not_the_harness() {
+        // The recorded version must be the measured core crate's version
+        // (from build.rs), not this bench harness's own CARGO_PKG_VERSION.
+        // A regression to `env!("CARGO_PKG_VERSION")` would fail here
+        // whenever core and bench versions differ (the real-world case).
+        let snap = create_snapshot(Vec::new(), 256, 1_000_000);
+        assert_eq!(snap.version, core_version());
+        assert_eq!(snap.git_sha, core_git_sha());
+        assert!(!snap.version.is_empty());
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -19,8 +19,9 @@ use std::fs;
 use std::path::Path;
 
 use libviprs_bench::{
-    comparison_suite, create_snapshot, generate_charts, generate_history_chart, load_history,
-    print_comparison_table, print_savings_summary, save_history,
+    comparison_suite, core_git_sha, core_version, create_snapshot, generate_charts,
+    generate_history_chart, load_history, print_comparison_table, print_savings_summary,
+    save_history,
 };
 
 fn main() {
@@ -33,7 +34,12 @@ fn main() {
     let streaming_budget: u64 = 1_000_000; // 1 MB
 
     println!("=== libviprs engine comparison benchmark (monolithic / streaming / mapreduce) ===");
-    println!("    version: {}", env!("CARGO_PKG_VERSION"));
+    println!(
+        "    measured libviprs core: {} ({})",
+        core_version(),
+        core_git_sha()
+    );
+    println!("    bench harness: {}", env!("CARGO_PKG_VERSION"));
     println!();
     println!("Tile size: {tile_size}, memory budget: {streaming_budget} bytes");
     println!(
@@ -66,8 +72,11 @@ fn main() {
     let mut txt = String::new();
     txt.push_str(&format!(
         "libviprs engine comparison benchmark (monolithic / streaming / mapreduce)\n\
-         version: {}\n\
+         measured libviprs core: {} ({})\n\
+         bench harness: {}\n\
          Tile size: {tile_size}, memory budget: {streaming_budget} bytes\n\n",
+        core_version(),
+        core_git_sha(),
         env!("CARGO_PKG_VERSION"),
     ));
 
@@ -108,35 +117,53 @@ fn main() {
     println!("Charts written:");
     println!("  {}", report_dir.join("chart_wall_time.svg").display());
     println!("  {}", report_dir.join("chart_peak_memory.svg").display());
-    println!("  {}", report_dir.join("chart_tracked_memory.svg").display());
+    println!(
+        "  {}",
+        report_dir.join("chart_tracked_memory.svg").display()
+    );
     println!("  {}", report_dir.join("chart_throughput.svg").display());
     println!("  {}", report_dir.join("chart_efficiency.svg").display());
     println!("  {}", report_dir.join("chart_resource_cost.svg").display());
 
     // --- Versioned benchmark history ---
+    //
+    // If the existing history file is corrupt, I refuse to overwrite it:
+    // appending a fresh snapshot would clobber every prior run. I keep
+    // the old file in place, report the problem, and skip this run's
+    // append so the accumulated history survives for inspection/repair.
     let history_path = report_dir.join("benchmark_history.json");
-    let mut history = load_history(&history_path);
-
-    let snapshot = create_snapshot(results.clone(), tile_size, streaming_budget);
-    history.push(snapshot);
-
-    save_history(&history_path, &history);
     println!();
-    println!(
-        "Benchmark history updated: {} entries in {}",
-        history.len(),
-        history_path.display()
-    );
+    match load_history(&history_path) {
+        Ok(mut history) => {
+            let snapshot = create_snapshot(results.clone(), tile_size, streaming_budget);
+            history.push(snapshot);
+            save_history(&history_path, &history);
+            println!(
+                "Benchmark history updated: {} entries in {}",
+                history.len(),
+                history_path.display()
+            );
 
-    // Generate history trend charts if we have multiple versions
-    if history.len() >= 2 {
-        for &(w, h) in sizes {
-            for &conc in concurrency_levels {
-                generate_history_chart(&history, &report_dir, (w, h), conc);
+            // Generate history trend charts if we have multiple versions
+            if history.len() >= 2 {
+                for &(w, h) in sizes {
+                    for &conc in concurrency_levels {
+                        generate_history_chart(&history, &report_dir, (w, h), conc);
+                    }
+                }
+                println!("History trend charts written to {}", report_dir.display());
+            } else {
+                println!("(run again on a different version to generate trend charts)");
             }
         }
-        println!("History trend charts written to {}", report_dir.display());
-    } else {
-        println!("(run again on a different version to generate trend charts)");
+        Err(e) => {
+            eprintln!("warning: {e}");
+            eprintln!(
+                "Leaving {} untouched so prior history is not discarded.",
+                history_path.display()
+            );
+            eprintln!("Fix or move the file, then re-run to resume appending snapshots.");
+            eprintln!("Skipping history trend charts for this run.");
+        }
     }
 }


### PR DESCRIPTION
Resolves libviprs/libviprs#154.

## Problem
Cross-version benchmark history recorded the wrong crate on every snapshot. `create_snapshot` stamped `env!("CARGO_PKG_VERSION")`, which is this bench harness's own version (0.3.0), while the measured engine is the `libviprs` core path dependency (0.3.1). The trend chart and cross-version report key on that field, so every version comparison was mislabeled.

Separately, `load_history` called `unwrap_or_default()` on a parse failure. A corrupt history file became an empty vec, and the next `save_history` overwrote the file with only the current run, silently destroying every accumulated snapshot.

## Fix
- New `build.rs` reads the measured core crate's version from `../libviprs/Cargo.toml` and its short git SHA, stamping both as compile-time env vars (`unknown` fallbacks so the library reads them unconditionally).
- `create_snapshot` records the core version and a new `git_sha` field. `git_sha` is `#[serde(default)]` so history files written before this change still parse.
- `load_history` now returns `Result`: a missing file is `Ok(empty)`, a corrupt file is an error. The `report` binary treats the error as "leave the existing file untouched", so prior history survives for inspection/repair instead of being discarded and this run's append is skipped.
- The `report` header and text report now print the measured core version + SHA alongside the harness version.

## Tests
Added `history_tests` covering: missing file is `Ok(empty)`, valid file round-trips, a corrupt file is reported as an error and left byte-for-byte intact on disk, and a snapshot records the measured core version (not the harness version).

## Acceptance criteria
- [x] Snapshots record the measured core crate's version + SHA.
- [x] A corrupt history file is reported, not silently dropped.

## Validation (local mirror)
`cargo fmt` (changed files clean), `cargo clippy --lib --bins --tests` green (no new warnings), `cargo test` green (4 new tests pass), `cargo check --features polars` green.