### PR TITLE
Repoint bench PDFium provenance to libviprs-dep verified binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,11 @@
 # a floating base image, an unpinned `libvips-dev`, or a `latest` PDFium
 # would silently change the numbers between runs (issue #153). Bump these
 # deliberately, never implicitly.
-#   PDFIUM_RELEASE  — bblanchon/pdfium-binaries release tag (was `latest`)
+#   PDFIUM_RELEASE  : libviprs-dep release tag (checksum-verified builder)
 #   LIBVIPS_VERSION — exact Debian bookworm `libvips*` package version
 # The Rust and Debian base images are pinned by tag on the FROM lines below.
 # ---------------------------------------------------------------------------
-ARG PDFIUM_RELEASE=chromium/7934
+ARG PDFIUM_RELEASE=pdfium-7881
 # Exact `libvips*` version currently in Debian bookworm. Debian only keeps the
 # newest security build of a package on the live mirror, so this must name the
 # current `8.14.1-3+deb12uN` — bump `N` when a new bookworm security update
@@ -33,18 +33,23 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
 ARG PDFIUM_RELEASE
-# The release tag contains a `/` (e.g. `chromium/7934`); it must be
-# percent-encoded to `%2F` in the download URL.
+# PDFium provenance (libviprs/libviprs#156): consume the pinned,
+# checksum-verified binaries published by libviprs-dep (the branch-pinned
+# builder that runs real ABI/symbol verification), the same source
+# libviprs-tests consumes. Keep PDFIUM_RELEASE and the per-arch SHA-256
+# digests in lockstep with libviprs-tests. The libviprs-dep tarball nests
+# its contents under a `pdfium-<arch>/` top directory, hence
+# `--strip-components=1`.
 RUN case "${TARGETARCH}" in \
-        amd64) PDFIUM_ARCH="linux-x64" ;; \
-        arm64) PDFIUM_ARCH="linux-arm64" ;; \
+        amd64) PDFIUM_ARCH="linux-x64";   PDFIUM_SHA256="653f24f074afe6c868f634ae0cc954a1a89821f33bc7795f16065a14022b662b" ;; \
+        arm64) PDFIUM_ARCH="linux-arm64"; PDFIUM_SHA256="3a8940ae414a54601f6bc0b25fb3d589025320ee91fff378e12708259da5702d" ;; \
         *)     echo "Unsupported arch: ${TARGETARCH}" && exit 1 ;; \
     esac && \
-    PDFIUM_TAG_ENC="$(echo "${PDFIUM_RELEASE}" | sed 's#/#%2F#g')" && \
     curl -fL -o /tmp/pdfium.tgz \
-        "https://github.com/bblanchon/pdfium-binaries/releases/download/${PDFIUM_TAG_ENC}/pdfium-${PDFIUM_ARCH}.tgz" && \
+        "https://github.com/libviprs/libviprs-dep/releases/download/${PDFIUM_RELEASE}/pdfium-${PDFIUM_ARCH}.tgz" && \
+    echo "${PDFIUM_SHA256}  /tmp/pdfium.tgz" | sha256sum -c - && \
     mkdir -p /opt/pdfium && \
-    tar xzf /tmp/pdfium.tgz -C /opt/pdfium && \
+    tar xzf /tmp/pdfium.tgz -C /opt/pdfium --strip-components=1 && \
     rm /tmp/pdfium.tgz
 
 # Stage 2: Build and run benchmarks

--- a/tests/pdfium_provenance.rs
+++ b/tests/pdfium_provenance.rs
@@ -1,0 +1,83 @@
+//! PDFium provenance guard (#156, filed in the core repo).
+//!
+//! The Docker harness must consume the pinned, checksum-verified PDFium
+//! binaries published by `libviprs-dep` (the branch-pinned builder that runs
+//! real ABI/symbol verification), matching what `libviprs-tests` already
+//! does. It must not fetch from the upstream `bblanchon/pdfium-binaries`
+//! channel at all: even a tag-pinned upstream download carries no checksum
+//! and is a different provenance source from the one the test suite
+//! certifies.
+//!
+//! These are cheap source-level CI checks in the style of
+//! `tests/vips_ffi.rs`: they fail the moment the Dockerfile's fetch step
+//! drifts off the verified source, without needing Docker in the loop.
+
+const DOCKERFILE: &str = include_str!("../Dockerfile");
+
+/// The pdfium stage must download from libviprs-dep's release, not from
+/// bblanchon/pdfium-binaries (neither `latest` nor a pinned tag).
+#[test]
+fn dockerfile_fetches_pdfium_from_libviprs_dep() {
+    assert!(
+        !DOCKERFILE.contains("bblanchon"),
+        "Dockerfile still references bblanchon/pdfium-binaries; the bench \
+         image must consume the verified libviprs-dep release (see \
+         libviprs/libviprs#156)"
+    );
+    assert!(
+        DOCKERFILE.contains("github.com/libviprs/libviprs-dep/releases/download"),
+        "Dockerfile must download PDFium from the libviprs-dep release \
+         (see libviprs/libviprs#156)"
+    );
+    assert!(
+        DOCKERFILE.contains("PDFIUM_RELEASE=pdfium-7881"),
+        "Dockerfile must pin the libviprs-dep `pdfium-7881` release tag, in \
+         lockstep with libviprs-tests (see libviprs/libviprs#156)"
+    );
+}
+
+/// The download must be integrity-checked before extraction: a pinned URL
+/// without a digest still trusts the remote end forever.
+#[test]
+fn dockerfile_verifies_pdfium_checksum() {
+    assert!(
+        DOCKERFILE.contains("sha256sum -c"),
+        "Dockerfile must verify the PDFium tarball against a pinned SHA-256 \
+         digest with `sha256sum -c` (see libviprs/libviprs#156)"
+    );
+    // Per-arch digests of the live pdfium-7881 assets; these are the same
+    // values libviprs-tests pins. If libviprs-dep republishes the release,
+    // update both repos together.
+    let digests = [
+        // pdfium-linux-x64.tgz
+        "653f24f074afe6c868f634ae0cc954a1a89821f33bc7795f16065a14022b662b",
+        // pdfium-linux-arm64.tgz
+        "3a8940ae414a54601f6bc0b25fb3d589025320ee91fff378e12708259da5702d",
+    ];
+    for digest in digests {
+        assert!(
+            DOCKERFILE.contains(digest),
+            "Dockerfile is missing the pinned SHA-256 digest {digest} for a \
+             pdfium-7881 architecture (see libviprs/libviprs#156)"
+        );
+    }
+}
+
+/// libviprs-dep tarballs nest their contents under a `pdfium-<arch>/` top
+/// directory (unlike the flat upstream layout), so extraction must strip one
+/// path component for `/opt/pdfium/lib/libpdfium.so` to land where the
+/// builder stage copies it from.
+#[test]
+fn dockerfile_strips_nested_tarball_layout() {
+    assert!(
+        DOCKERFILE.contains("--strip-components=1"),
+        "Dockerfile must extract the libviprs-dep tarball with \
+         `--strip-components=1`; its contents are nested one directory deep \
+         (see libviprs/libviprs#156)"
+    );
+    assert!(
+        DOCKERFILE.contains("/opt/pdfium/lib/libpdfium.so"),
+        "builder stage must copy libpdfium.so from the pdfium stage's \
+         /opt/pdfium/lib path"
+    );
+}


### PR DESCRIPTION
## What

I complete the libviprs-bench half of libviprs/libviprs#156 (the libviprs-tests half landed via libviprs-tests #61 and #62). The Dockerfile's pdfium stage now consumes the pinned, checksum-verified `pdfium-7881` release published by libviprs-dep instead of `bblanchon/pdfium-binaries`.

- `PDFIUM_RELEASE=pdfium-7881`, downloaded from `github.com/libviprs/libviprs-dep/releases`, in lockstep with libviprs-tests (same tag, same digests).
- Per-arch SHA-256 verification with `sha256sum -c` before extraction: a pinned URL without a digest still trusts the remote end forever.
- `--strip-components=1` on extraction: the libviprs-dep tarball nests its contents under a `pdfium-<arch>/` top directory, unlike the flat upstream layout.

## Test

I add `tests/pdfium_provenance.rs`, cheap source-level guards in the style of `tests/vips_ffi.rs`. They assert the Dockerfile fetches from libviprs-dep (and never bblanchon), pins the `pdfium-7881` tag and both per-arch digests, verifies with `sha256sum -c`, and extracts with `--strip-components=1` to the path the builder stage copies from. All three tests fail on the previous Dockerfile (verified red first) and pass after this change.

## Verification

- Both release asset URLs return 200 and the pinned digests match the live assets (recomputed locally with `shasum -a 256`).
- A no-cache `docker build --target pdfium --platform linux/amd64` downloaded the tarball, checksum-verified it (`OK`), and extracted `libpdfium.so` to `/opt/pdfium/lib/libpdfium.so`, the exact path the builder stage `COPY`s from.
- Local mirror green: `cargo test` (9 passed incl. the 3 new guards), `cargo clippy --lib --tests` clean of new warnings, and the new test file is rustfmt-clean. The rustfmt drift in `src/cross_version.rs` / `src/scalability.rs` pre-exists on main and CI has no fmt gate; I leave it untouched here.

Closes libviprs/libviprs#156