### PR TITLE
chore: repin pdfium-render fork to libviprs/integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,4 +74,4 @@ required-features = ["polars"]
 # `Pdfium`. Keep this pin in lockstep with `../libviprs/Cargo.toml`;
 # drop both once the fork is upstreamed and released.
 [patch.crates-io]
-pdfium-render = { git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/per-call-thread-safety" }
+pdfium-render = { git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/integration" }


### PR DESCRIPTION
Move the pdfium-render `[patch.crates-io]` pin from `libviprs/per-call-thread-safety` to the consolidated `libviprs/integration` branch of libviprs/pdfium-render, keeping it in lockstep with the core crate's pin.

Scope is limited to the `[patch.crates-io]` entry in Cargo.toml (Cargo.lock is gitignored here). `cargo check --all-features` resolves the pin to `libviprs/integration` at commit 1000a1a and builds pdfium-render plus the full workspace cleanly. No source or other dependency changed.