### PR TITLE
Match EngineEvent 0.4.0 TileCompleted new fields [skip ci]

### DIFF
--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -46,7 +46,7 @@ fn events_to_folded_stacks(events: &[EngineEvent], engine_name: &str) -> Vec<Str
                 _level_tiles = 0;
                 stacks.push(format!("{engine_name};level_{level}_start {tile_count}"));
             }
-            EngineEvent::TileCompleted { coord } => {
+            EngineEvent::TileCompleted { coord, .. } => {
                 _level_tiles += 1;
                 if let Some(lvl) = current_level {
                     stacks.push(format!(


### PR DESCRIPTION
Core 0.4.0 added worker_id and timestamp to TileCompleted, TileFailed, TileSkippedOnResume, and RetryAttempted. Only the flamegraph TileCompleted destructure named its fields exactly; I widen it with `..` so it ignores the new fields. The other three variants already fall through the wildcard arm.

Verified locally: cargo check and cargo check --features pdfium both compile clean against the 0.4.0 core.