### PR TITLE
Dockerfile: build + record a pinned modern libvips (#24)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,11 @@ criterion = { version = "0.5", features = ["html_reports"] }
 image = "0.25"
 inferno = "0.12"
 libc = "0.2"
+# In-process libvips FFI (gated by the `libvips` feature). Its major.minor
+# MUST track the libvips the container builds — `provenance::PINNED_LIBVIPS_VERSION`
+# and the Dockerfile's `ARG LIBVIPS_VERSION` (both 8.18.x). Measuring one
+# libvips series through a different-series binding is its own mismatched
+# oracle (issue #33); `tests/libvips_provenance.rs` asserts they stay aligned.
 libvips-rs = { version = "8.18", optional = true }
 plotters = { version = "0.3", default-features = false, features = ["svg_backend", "line_series"] }
 polars = { version = "0.50", optional = true, default-features = false, features = [

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@
 # Pinned inputs. A benchmark is only reproducible if every layer is fixed:
 # a floating base image, an unpinned libvips, or a `latest` PDFium would
 # silently change the numbers between runs (issue #153). Bump these
-# deliberately, never implicitly.
+# deliberately, never implicitly. (One documented exception — the apt codec
+# `-dev` packages libvips links against are not snapshot-pinned; that scope is
+# spelled out in the builder stage and tracked in #35.)
 #   PDFIUM_RELEASE  — libviprs-dep release tag (checksum-verified builder)
 #   LIBVIPS_VERSION — upstream libvips source release, built from tarball
 #   LIBVIPS_SHA256  — SHA-256 of that tarball, verified before it is built
@@ -52,7 +54,7 @@ RUN case "${TARGETARCH}" in \
         arm64) PDFIUM_ARCH="linux-arm64"; PDFIUM_SHA256="3a8940ae414a54601f6bc0b25fb3d589025320ee91fff378e12708259da5702d" ;; \
         *)     echo "Unsupported arch: ${TARGETARCH}" && exit 1 ;; \
     esac && \
-    curl -fL -o /tmp/pdfium.tgz \
+    curl -fL --retry 3 --retry-delay 2 --retry-connrefused -o /tmp/pdfium.tgz \
         "https://github.com/libviprs/libviprs-dep/releases/download/${PDFIUM_RELEASE}/pdfium-${PDFIUM_ARCH}.tgz" && \
     echo "${PDFIUM_SHA256}  /tmp/pdfium.tgz" | sha256sum -c - && \
     mkdir -p /opt/pdfium && \
@@ -77,6 +79,16 @@ ARG LIBVIPS_SHA256
 # the image-format `-dev` libraries it links against. Only PNG is on the
 # benchmark's hot path (DeepZoom writes PNG tiles), but jpeg/tiff/webp are
 # included so the oracle is a realistic, full-featured libvips build.
+#
+# Reproducibility scope (issue #33, tracked in #35): libvips itself is pinned
+# by version + SHA-256 and the base images by tag, but these apt `-dev`
+# packages are NOT snapshot-pinned — `apt-get install` resolves them against
+# bookworm's live mirror, so an intra-bookworm point release (e.g. a libpng
+# security update) can shift under a rebuild. Accepted deliberately here:
+# point releases hold ABI and rarely move the encode hot path materially, and
+# the meson force-enable below fails the build if a codec disappears entirely.
+# Fully closing this (a dated snapshot.debian.org source or digest-pinned
+# base) is deferred to #35.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -100,15 +112,20 @@ RUN apt-get update && \
 # URL without a digest still trusts the remote end forever — the same rule the
 # PDFium stage follows), then built release-mode into /usr/local. `--libdir=lib`
 # keeps `vips.pc` under /usr/local/lib/pkgconfig where pkg-config finds it
-# without a multiarch subdir; meson auto-detects features from the `-dev`
-# libraries installed above.
-RUN curl -fL -o /tmp/vips.tar.xz \
+# without a multiarch subdir. The codec `-dev` libraries are force-enabled
+# (`-Dpng/jpeg/tiff/webp=enabled`) rather than left to meson's `auto`
+# detection, so a missing or broken codec lib hard-fails the build instead of
+# silently producing a libvips without it — a PNG-less oracle would quietly
+# invalidate the DeepZoom PNG-tile hot path (issue #33). `curl --retry`
+# absorbs a transient network blip on the now-multi-minute build.
+RUN curl -fL --retry 3 --retry-delay 2 --retry-connrefused -o /tmp/vips.tar.xz \
         "https://github.com/libvips/libvips/releases/download/v${LIBVIPS_VERSION}/vips-${LIBVIPS_VERSION}.tar.xz" && \
     echo "${LIBVIPS_SHA256}  /tmp/vips.tar.xz" | sha256sum -c - && \
     mkdir -p /tmp/vips-src && \
     tar xJf /tmp/vips.tar.xz -C /tmp/vips-src --strip-components=1 && \
     cd /tmp/vips-src && \
-    meson setup build --buildtype=release --prefix=/usr/local --libdir=lib && \
+    meson setup build --buildtype=release --prefix=/usr/local --libdir=lib \
+        -Dpng=enabled -Djpeg=enabled -Dtiff=enabled -Dwebp=enabled && \
     ninja -C build && \
     ninja -C build install && \
     ldconfig && \
@@ -121,8 +138,16 @@ ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 COPY --from=pdfium /opt/pdfium/lib/libpdfium.so /usr/local/lib/libpdfium.so
 RUN ldconfig
 
-# Verify the built libvips is the pinned version and is discoverable
-RUN vips --version && pkg-config --modversion vips
+# Verify the built libvips is *exactly* the pinned version and is discoverable
+# by pkg-config. Comparing the modversion against ${LIBVIPS_VERSION} (not just
+# printing it) fails the build if a stray or wrong-version libvips is ahead on
+# PATH / in the pkg-config path, rather than silently benchmarking it (#33).
+RUN vips --version && \
+    modversion="$(pkg-config --modversion vips)" && \
+    if [ "$modversion" != "${LIBVIPS_VERSION}" ]; then \
+        echo "built libvips modversion ${modversion} != pinned ${LIBVIPS_VERSION}" >&2; \
+        exit 1; \
+    fi
 
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,25 +6,32 @@
 # to a real on-disk sink with the same codec, so neither side gets a
 # filesystem-I/O or encoding advantage (issue #153).
 #
+# libvips is compiled from a pinned upstream *source* tarball (not Debian's
+# frozen `libvips-dev`), so the C oracle is a recent release matched to the
+# `libvips-rs` 8.18 bindings rather than a years-old ~8.14 mismatch (#33).
+#
 # Build:  docker build -t libviprs-bench .
 # Run:    docker run --rm libviprs-bench
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
 # Pinned inputs. A benchmark is only reproducible if every layer is fixed:
-# a floating base image, an unpinned `libvips-dev`, or a `latest` PDFium
-# would silently change the numbers between runs (issue #153). Bump these
+# a floating base image, an unpinned libvips, or a `latest` PDFium would
+# silently change the numbers between runs (issue #153). Bump these
 # deliberately, never implicitly.
-#   PDFIUM_RELEASE  : libviprs-dep release tag (checksum-verified builder)
-#   LIBVIPS_VERSION — exact Debian bookworm `libvips*` package version
+#   PDFIUM_RELEASE  — libviprs-dep release tag (checksum-verified builder)
+#   LIBVIPS_VERSION — upstream libvips source release, built from tarball
+#   LIBVIPS_SHA256  — SHA-256 of that tarball, verified before it is built
 # The Rust and Debian base images are pinned by tag on the FROM lines below.
 # ---------------------------------------------------------------------------
 ARG PDFIUM_RELEASE=pdfium-7881
-# Exact `libvips*` version currently in Debian bookworm. Debian only keeps the
-# newest security build of a package on the live mirror, so this must name the
-# current `8.14.1-3+deb12uN` — bump `N` when a new bookworm security update
-# lands (otherwise `apt-get install` cannot resolve the pinned version).
-ARG LIBVIPS_VERSION=8.14.1-3+deb12u3
+# Upstream libvips release compiled from source (issue #33). Kept in lockstep
+# with `provenance::PINNED_LIBVIPS_VERSION` and the `libvips-rs` binding in
+# Cargo.toml — `tests/libvips_provenance.rs` fails if they drift. Bump all
+# three together, refreshing LIBVIPS_SHA256 from the upstream
+# `vips-<version>.tar.xz.sha256sum` companion file.
+ARG LIBVIPS_VERSION=8.18.4
+ARG LIBVIPS_SHA256=2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037
 
 # Stage 1: Download PDFium for the target architecture
 FROM debian:bookworm-20250929-slim AS pdfium
@@ -58,26 +65,64 @@ RUN case "${TARGETARCH}" in \
 FROM rust:1.89-bookworm AS builder
 
 ARG LIBVIPS_VERSION
+ARG LIBVIPS_SHA256
 
-# Install libvips development headers and runtime (C library for comparison)
-# plus pkg-config for the build script to find it. `libvips*` are pinned to an
-# exact Debian version so the C baseline is fixed run-to-run; bump
-# LIBVIPS_VERSION deliberately when refreshing the environment.
+# Build libvips from a pinned upstream source tarball rather than installing
+# Debian's frozen `libvips-dev` (issue #33): bookworm ships ~8.14, years
+# behind the `libvips-rs` 8.18 bindings, so the apt package made the C oracle
+# an unfair, mismatched baseline. A source build gives a recent release
+# matched to the bindings, fixed by version + SHA-256.
+#
+# Two dependency sets: the meson/ninja toolchain that compiles libvips, and
+# the image-format `-dev` libraries it links against. Only PNG is on the
+# benchmark's hot path (DeepZoom writes PNG tiles), but jpeg/tiff/webp are
+# included so the oracle is a realistic, full-featured libvips build.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
-        "libvips-dev=${LIBVIPS_VERSION}" \
-        "libvips-tools=${LIBVIPS_VERSION}" \
+        curl \
+        xz-utils \
+        build-essential \
+        meson \
+        ninja-build \
         pkg-config \
+        libglib2.0-dev \
+        libexpat1-dev \
+        libpng-dev \
+        libjpeg62-turbo-dev \
+        libtiff-dev \
+        libwebp-dev \
         time \
     && rm -rf /var/lib/apt/lists/*
+
+# Download, checksum-verify, and compile the pinned libvips release. The
+# tarball is verified against LIBVIPS_SHA256 before it is unpacked (a pinned
+# URL without a digest still trusts the remote end forever — the same rule the
+# PDFium stage follows), then built release-mode into /usr/local. `--libdir=lib`
+# keeps `vips.pc` under /usr/local/lib/pkgconfig where pkg-config finds it
+# without a multiarch subdir; meson auto-detects features from the `-dev`
+# libraries installed above.
+RUN curl -fL -o /tmp/vips.tar.xz \
+        "https://github.com/libvips/libvips/releases/download/v${LIBVIPS_VERSION}/vips-${LIBVIPS_VERSION}.tar.xz" && \
+    echo "${LIBVIPS_SHA256}  /tmp/vips.tar.xz" | sha256sum -c - && \
+    mkdir -p /tmp/vips-src && \
+    tar xJf /tmp/vips.tar.xz -C /tmp/vips-src --strip-components=1 && \
+    cd /tmp/vips-src && \
+    meson setup build --buildtype=release --prefix=/usr/local --libdir=lib && \
+    ninja -C build && \
+    ninja -C build install && \
+    ldconfig && \
+    rm -rf /tmp/vips.tar.xz /tmp/vips-src
+
+# Let the build script's pkg-config probe find the freshly built libvips.
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
 # Install PDFium shared library
 COPY --from=pdfium /opt/pdfium/lib/libpdfium.so /usr/local/lib/libpdfium.so
 RUN ldconfig
 
-# Verify libvips is installed and accessible
-RUN vips --version && pkg-config --libs vips
+# Verify the built libvips is the pinned version and is discoverable
+RUN vips --version && pkg-config --modversion vips
 
 WORKDIR /src
 

--- a/run-bench.sh
+++ b/run-bench.sh
@@ -73,6 +73,13 @@ esac
 CONTAINER_NAME="libviprs-bench"
 IMAGE_NAME="libviprs-bench:local"
 
+# The libvips release the Docker image builds from source (issue #33), read
+# from the Dockerfile so this script and the image share a single pin. Shown
+# in the banners below; inside the container it is also recorded into each
+# snapshot's provenance (the measured-vs-pinned oracle).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIBVIPS_PIN="$(sed -n 's/^ARG LIBVIPS_VERSION=//p' "$SCRIPT_DIR/Dockerfile" | head -1)"
+
 # Pinned measurement RUSTFLAGS. Recorded into every snapshot's provenance
 # (build.rs stamps $RUSTFLAGS) so the reported numbers carry the exact
 # codegen config they were measured under. Kept in lockstep with the
@@ -92,7 +99,8 @@ if [ "$NO_BUILD" = true ]; then
     FEATURES=""
     if pkg-config --exists vips 2>/dev/null; then
         FEATURES="--features libvips"
-        echo "libvips detected via pkg-config — using in-process FFI"
+        echo "libvips detected via pkg-config ($(pkg-config --modversion vips)) — using in-process FFI"
+        echo "  (Docker path pins libvips ${LIBVIPS_PIN:-unknown}, built from source)"
     else
         echo "libvips not found — falling back to CLI comparison"
     fi
@@ -126,7 +134,6 @@ if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
     docker rm -f "$CONTAINER_NAME" >/dev/null
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 WORKSPACE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 echo "=== libviprs benchmark (${ARCH_LABEL}, ${MEMORY_MB} MB) ==="
@@ -134,6 +141,7 @@ echo ""
 echo "Building Docker image..."
 echo "  Platform:  ${PLATFORM}"
 echo "  Workspace: ${WORKSPACE_DIR}"
+echo "  libvips:   ${LIBVIPS_PIN:-unknown} (built from source, issue #33)"
 echo "  Command:   ${BENCH_CMD}"
 echo ""
 

--- a/src/cross_version.rs
+++ b/src/cross_version.rs
@@ -28,6 +28,7 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use libviprs_bench::provenance::OracleMatch;
 use libviprs_bench::{BenchmarkSnapshot, RunMetrics};
 use polars::prelude::*;
 
@@ -47,6 +48,22 @@ fn main() {
     if history.is_empty() {
         eprintln!("History file is empty — nothing to compare.");
         std::process::exit(1);
+    }
+
+    // Flag any snapshot whose measured libvips diverged from the oracle it was
+    // pinned to build (issue #33). `fingerprint()` already sorts such a run
+    // into its own measured-version column, but call the mismatch out by name
+    // so a reader knows that column is an artifact of a mispinned build, not a
+    // real libvips under test.
+    for snap in &history {
+        if let OracleMatch::Mismatch { measured, pinned } = snap.provenance.libvips_oracle_match() {
+            eprintln!(
+                "WARNING: snapshot {} ({}) measured libvips {}.{} but was pinned \
+                 to {}.{} — mismatched oracle (issue #33); its column is not \
+                 comparable to pinned-oracle snapshots.",
+                snap.version, snap.timestamp, measured.0, measured.1, pinned.0, pinned.1
+            );
+        }
     }
 
     let mut df = build_dataframe(&history)

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -15,17 +15,33 @@ use serde::{Deserialize, Serialize};
 /// The exact upstream libvips release the benchmark container is pinned to
 /// build from source and measure against.
 ///
-/// Single source of truth for the pinned oracle. The `Dockerfile` builds
-/// `vips-{PINNED_LIBVIPS_VERSION}.tar.xz` from upstream (checksum-verified),
-/// the `libvips-rs` binding in `Cargo.toml` tracks the same major.minor
-/// series, and [`Provenance::capture`] stamps it into every snapshot as
-/// [`Provenance::pinned_libvips_version`]. `tests/libvips_provenance.rs`
-/// fails the moment any of those three drift from this constant.
+/// Canonical declaration of the pinned oracle version, kept in lockstep with
+/// its other homes by `tests/libvips_provenance.rs`: the `Dockerfile` builds
+/// `vips-{PINNED_LIBVIPS_VERSION}.tar.xz` from upstream (checksum-verified
+/// against [`PINNED_LIBVIPS_SHA256`]), the `libvips-rs` binding in
+/// `Cargo.toml` tracks the same major.minor series, and
+/// [`Provenance::capture`] stamps it into every snapshot as
+/// [`Provenance::pinned_libvips_version`]. Those tests fail the moment any of
+/// those homes drift from this constant.
 ///
 /// Chosen to match the `libvips-rs` 8.18 bindings — replacing Debian
 /// bookworm's frozen ~8.14 `libvips-dev`, which trailed the bindings by
 /// years and made the C baseline an unfair, mismatched oracle (issue #33).
 pub const PINNED_LIBVIPS_VERSION: &str = "8.18.4";
+
+/// SHA-256 of `vips-{PINNED_LIBVIPS_VERSION}.tar.xz`, the digest the
+/// `Dockerfile` verifies the downloaded tarball against before it is built.
+///
+/// Lives next to the version it belongs to so a pin bump and its digest have
+/// a single home, the same lockstep treatment [`PINNED_LIBVIPS_VERSION`]
+/// already enjoys; `tests/libvips_provenance.rs` asserts the Dockerfile pins
+/// exactly this value. Cross-checked against the upstream
+/// `vips-{PINNED_LIBVIPS_VERSION}.tar.xz.sha256sum` companion file — refresh
+/// it in the same edit whenever [`PINNED_LIBVIPS_VERSION`] is bumped.
+/// Validating the digest against the *real* upstream tarball on a schedule is
+/// tracked as a follow-up (libviprs-bench #36).
+pub const PINNED_LIBVIPS_SHA256: &str =
+    "2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037";
 
 /// Host + toolchain fingerprint for one benchmark snapshot.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -99,6 +115,33 @@ impl Default for Provenance {
     }
 }
 
+/// Outcome of comparing the libvips actually measured against the pinned
+/// build target ([`PINNED_LIBVIPS_VERSION`]) at `major.minor`.
+///
+/// Distinguishes a genuine mismatched oracle — a containerized run that built
+/// or linked a different libvips than it was pinned to (issue #33) — from the
+/// merely *indeterminate* case where a version string could not be parsed
+/// (e.g. the `"unknown"` sentinel a host run without libvips records). The two
+/// warrant different handling: a mismatch is a loud warning that the run's
+/// numbers are not comparable to a pinned-oracle run; an indeterminate result
+/// is the ordinary "no libvips here" state and must not cry wolf.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OracleMatch {
+    /// Measured and pinned agree at `major.minor`.
+    Match,
+    /// Both sides parsed but differ — the mismatched oracle #33 guards against.
+    Mismatch {
+        /// `(major, minor)` actually measured.
+        measured: (u32, u32),
+        /// `(major, minor)` the environment was pinned to.
+        pinned: (u32, u32),
+    },
+    /// Either side is unparseable (e.g. `"unknown"`), so no verdict is
+    /// possible — treated as "not a match" by
+    /// [`Provenance::libvips_matches_pinned`].
+    Indeterminate,
+}
+
 impl Provenance {
     /// Capture the current environment.
     pub fn capture() -> Provenance {
@@ -146,21 +189,33 @@ impl Provenance {
         )
     }
 
-    /// Whether the libvips actually measured matches the pinned build target
+    /// Classify the libvips actually measured against the pinned build target
     /// ([`Provenance::pinned_libvips_version`]) at `major.minor`.
     ///
-    /// Equal by construction inside the pinned container; a `false` here on a
-    /// containerized run means the image built or linked a different libvips
-    /// than it was pinned to — the mismatched-oracle failure #33 closes.
-    /// `false` whenever either side is unparseable (e.g. `"unknown"`).
-    pub fn libvips_matches_pinned(&self) -> bool {
+    /// Equal by construction inside the pinned container; an
+    /// [`OracleMatch::Mismatch`] on a containerized run means the image built
+    /// or linked a different libvips than it was pinned to — the failure #33
+    /// closes. The `report`, `scalability`, and `cross_version` binaries call
+    /// this and surface a mismatch loudly (a mismatch alone is a warning, not
+    /// an [`OracleMatch::Indeterminate`] "unknown", so a plain host run with no
+    /// libvips never trips a false alarm).
+    pub fn libvips_oracle_match(&self) -> OracleMatch {
         match (
             parse_libvips_major_minor(&self.libvips_version),
             parse_libvips_major_minor(&self.pinned_libvips_version),
         ) {
-            (Some(measured), Some(pinned)) => measured == pinned,
-            _ => false,
+            (Some(measured), Some(pinned)) if measured == pinned => OracleMatch::Match,
+            (Some(measured), Some(pinned)) => OracleMatch::Mismatch { measured, pinned },
+            _ => OracleMatch::Indeterminate,
         }
+    }
+
+    /// Whether the measured libvips matches the pinned build target at
+    /// `major.minor`. A thin `bool` view of [`Provenance::libvips_oracle_match`]:
+    /// `false` for both a real [`OracleMatch::Mismatch`] and an unparseable
+    /// ([`OracleMatch::Indeterminate`], e.g. `"unknown"`) side.
+    pub fn libvips_matches_pinned(&self) -> bool {
+        matches!(self.libvips_oracle_match(), OracleMatch::Match)
     }
 }
 
@@ -170,7 +225,10 @@ impl Provenance {
 /// already-stripped form [`libvips_version`] stores (`"8.18.4"` / `"8.18"`).
 /// Returns `None` for anything without at least a numeric `major.minor`
 /// (e.g. the `"unknown"` sentinel), so a missing capture never compares
-/// equal to a real version.
+/// equal to a real version. A component carrying a non-digit suffix — a
+/// pre-release tag like `"8.18-rc1"` — also yields `None` by design: the
+/// pinned oracle is always a finished release, so a suffixed string is an
+/// unexpected capture, not a version worth comparing.
 pub fn parse_libvips_major_minor(version: &str) -> Option<(u32, u32)> {
     let trimmed = version.trim();
     let digits = trimmed.strip_prefix("vips-").unwrap_or(trimmed);

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -5,17 +5,45 @@
 //! on a 4-core CI box against a libvips-8.18 run on a 10-core laptop is
 //! not a version delta — it is an environment delta wearing a version
 //! delta's clothes. [`Provenance`] records enough of the environment
-//! (libvips version, measurement path, host CPU/OS/arch, container flag,
-//! rustc, build profile) that `cross_version` can *group by* fingerprint
-//! and refuse — or at least loudly flag — cross-environment deltas.
+//! (libvips version — both measured and pinned, measurement path, host
+//! CPU/OS/arch, container flag, rustc, build profile) that `cross_version`
+//! can *group by* fingerprint and refuse — or at least loudly flag —
+//! cross-environment deltas.
 
 use serde::{Deserialize, Serialize};
+
+/// The exact upstream libvips release the benchmark container is pinned to
+/// build from source and measure against.
+///
+/// Single source of truth for the pinned oracle. The `Dockerfile` builds
+/// `vips-{PINNED_LIBVIPS_VERSION}.tar.xz` from upstream (checksum-verified),
+/// the `libvips-rs` binding in `Cargo.toml` tracks the same major.minor
+/// series, and [`Provenance::capture`] stamps it into every snapshot as
+/// [`Provenance::pinned_libvips_version`]. `tests/libvips_provenance.rs`
+/// fails the moment any of those three drift from this constant.
+///
+/// Chosen to match the `libvips-rs` 8.18 bindings — replacing Debian
+/// bookworm's frozen ~8.14 `libvips-dev`, which trailed the bindings by
+/// years and made the C baseline an unfair, mismatched oracle (issue #33).
+pub const PINNED_LIBVIPS_VERSION: &str = "8.18.4";
 
 /// Host + toolchain fingerprint for one benchmark snapshot.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Provenance {
-    /// libvips runtime version (e.g. `"8.18.4"`), or `"unknown"`.
+    /// libvips runtime version actually measured (e.g. `"8.18.4"`), or
+    /// `"unknown"`. Queried from the linked library / `vips` CLI at capture.
     pub libvips_version: String,
+    /// The libvips release the environment was *pinned to build and measure*
+    /// ([`PINNED_LIBVIPS_VERSION`]), recorded so every snapshot carries the
+    /// intended oracle next to the one actually measured above. In the
+    /// container the two are equal by construction; a divergence flags a run
+    /// that measured a different libvips than it was pinned to (issue #33 —
+    /// see [`Provenance::libvips_matches_pinned`]). Kept out of
+    /// [`Provenance::fingerprint`] on purpose: the *measured* version is what
+    /// groups comparable runs. Defaults to `"unknown"` for history written
+    /// before this axis existed.
+    #[serde(default = "unknown_libvips")]
+    pub pinned_libvips_version: String,
     /// rustc version string captured at build time, or `"unknown"`.
     pub rustc_version: String,
     /// Cargo build profile the harness was compiled with: `"release"` or
@@ -41,6 +69,13 @@ pub struct HostInfo {
     pub in_container: bool,
 }
 
+/// serde default for [`Provenance::pinned_libvips_version`] when a snapshot
+/// predates the pinned-version axis: the same `"unknown"` sentinel the rest
+/// of a pre-provenance fingerprint uses.
+fn unknown_libvips() -> String {
+    "unknown".to_string()
+}
+
 impl Default for Provenance {
     /// The fingerprint used for history written before provenance existed:
     /// everything `"unknown"`. Its [`Provenance::fingerprint`] never
@@ -49,6 +84,7 @@ impl Default for Provenance {
     fn default() -> Self {
         Provenance {
             libvips_version: "unknown".to_string(),
+            pinned_libvips_version: "unknown".to_string(),
             rustc_version: "unknown".to_string(),
             build_profile: "unknown".to_string(),
             build_flags: String::new(),
@@ -68,6 +104,7 @@ impl Provenance {
     pub fn capture() -> Provenance {
         Provenance {
             libvips_version: libvips_version(),
+            pinned_libvips_version: PINNED_LIBVIPS_VERSION.to_string(),
             rustc_version: option_env!("BENCH_RUSTC_VERSION")
                 .unwrap_or("unknown")
                 .to_string(),
@@ -108,6 +145,39 @@ impl Provenance {
             },
         )
     }
+
+    /// Whether the libvips actually measured matches the pinned build target
+    /// ([`Provenance::pinned_libvips_version`]) at `major.minor`.
+    ///
+    /// Equal by construction inside the pinned container; a `false` here on a
+    /// containerized run means the image built or linked a different libvips
+    /// than it was pinned to — the mismatched-oracle failure #33 closes.
+    /// `false` whenever either side is unparseable (e.g. `"unknown"`).
+    pub fn libvips_matches_pinned(&self) -> bool {
+        match (
+            parse_libvips_major_minor(&self.libvips_version),
+            parse_libvips_major_minor(&self.pinned_libvips_version),
+        ) {
+            (Some(measured), Some(pinned)) => measured == pinned,
+            _ => false,
+        }
+    }
+}
+
+/// Parse a libvips version string down to `(major, minor)`.
+///
+/// Accepts both the raw `vips --version` line (`"vips-8.18.4"`) and the
+/// already-stripped form [`libvips_version`] stores (`"8.18.4"` / `"8.18"`).
+/// Returns `None` for anything without at least a numeric `major.minor`
+/// (e.g. the `"unknown"` sentinel), so a missing capture never compares
+/// equal to a real version.
+pub fn parse_libvips_major_minor(version: &str) -> Option<(u32, u32)> {
+    let trimmed = version.trim();
+    let digits = trimmed.strip_prefix("vips-").unwrap_or(trimmed);
+    let mut parts = digits.split('.');
+    let major = parts.next()?.parse::<u32>().ok()?;
+    let minor = parts.next()?.parse::<u32>().ok()?;
+    Some((major, minor))
 }
 
 /// Query the libvips version. Prefers the linked library's own

--- a/src/report.rs
+++ b/src/report.rs
@@ -19,7 +19,7 @@ use std::fs;
 use std::path::Path;
 
 use libviprs_bench::harness::{self, Engine};
-use libviprs_bench::provenance::Provenance;
+use libviprs_bench::provenance::{OracleMatch, Provenance};
 use libviprs_bench::{
     core_git_sha, core_version, create_snapshot, executive_verdict, generate_charts,
     generate_history_chart, load_history, print_comparison_table, print_savings_summary,
@@ -67,6 +67,23 @@ fn main() {
     println!("    bench harness: {}", env!("CARGO_PKG_VERSION"));
     println!("    environment:  {}", prov.fingerprint());
     println!("    cpu: {} ({} cpus)", prov.host.cpu_model, prov.host.ncpu);
+    println!(
+        "    libvips oracle: measured {} / pinned {}",
+        prov.libvips_version, prov.pinned_libvips_version
+    );
+    // Mismatched-oracle guard (#33): if this run measured a different libvips
+    // than the environment was pinned to build, its numbers are not comparable
+    // to a pinned-oracle run — say so loudly on stderr. Only fires on a genuine
+    // parsed mismatch, never on a host run that simply has no libvips.
+    if let OracleMatch::Mismatch { measured, pinned } = prov.libvips_oracle_match() {
+        eprintln!(
+            "WARNING: measured libvips {}.{} != pinned oracle {}.{} — this run \
+             measured a different libvips than the environment was pinned to \
+             build (issue #33); its numbers are NOT comparable to a \
+             pinned-oracle run.",
+            measured.0, measured.1, pinned.0, pinned.1
+        );
+    }
     println!();
     println!("Tile size: {tile_size}, memory budget: {streaming_budget} bytes");
     println!("Iterations: {iters} timed + {warmup} warm-up per cell (child-isolated)");

--- a/src/scalability.rs
+++ b/src/scalability.rs
@@ -30,6 +30,7 @@ use libviprs::{
     EngineBuilder, EngineConfig, EngineKind, FsSink, Layout, PyramidPlanner, Raster,
     RasterStripSource, TileFormat,
 };
+use libviprs_bench::provenance::{OracleMatch, Provenance};
 use libviprs_bench::{bench_libvips, gradient_raster, vips_available, write_temp_png};
 
 /// Peak RSS of the current process in bytes. Mirrors the RSS basis the
@@ -626,6 +627,20 @@ fn main() {
         println!("libvips CLI: included");
     } else {
         println!("libvips CLI: not found, skipping");
+    }
+    // Mismatched-oracle guard (#33) on the default container CMD: if this run
+    // measured a different libvips than the container was pinned to build, its
+    // numbers are not comparable to a pinned-oracle run — warn loudly. Only
+    // fires on a genuine parsed mismatch, never on a host run without libvips.
+    let prov = Provenance::capture();
+    if let OracleMatch::Mismatch { measured, pinned } = prov.libvips_oracle_match() {
+        eprintln!(
+            "WARNING: measured libvips {}.{} != pinned oracle {}.{} — this \
+             scalability run measured a different libvips than the container \
+             was pinned to build (issue #33); its numbers are NOT comparable \
+             to a pinned-oracle run.",
+            measured.0, measured.1, pinned.0, pinned.1
+        );
     }
     println!();
 

--- a/tests/libvips_provenance.rs
+++ b/tests/libvips_provenance.rs
@@ -1,0 +1,225 @@
+//! libvips pin + provenance guard (#24, sub-issue #33).
+//!
+//! The benchmark container must measure a *recent, matched* libvips, built
+//! from a pinned upstream source tarball — not Debian bookworm's frozen
+//! `libvips-dev` (~8.14.x), which trails the `libvips-rs` 8.18 bindings by
+//! years and makes the C oracle an unfair, mismatched baseline (#33). The
+//! pinned version is recorded as a provenance axis
+//! ([`PINNED_LIBVIPS_VERSION`]) so every containerized run stamps the exact
+//! libvips it was built to measure.
+//!
+//! A Dockerfile can't be unit-tested in-process, so these are cheap
+//! source-level checks in the style of `tests/pdfium_provenance.rs`: they
+//! read only committed files (the Dockerfile, Cargo.toml, and the recorded
+//! provenance constant) and fail the moment the pin drifts or the Dockerfile
+//! regresses to an unpinned / apt-installed libvips — without needing Docker
+//! or libvips in the loop.
+
+use libviprs_bench::provenance::{PINNED_LIBVIPS_VERSION, Provenance, parse_libvips_major_minor};
+
+const DOCKERFILE: &str = include_str!("../Dockerfile");
+const CARGO_TOML: &str = include_str!("../Cargo.toml");
+
+/// SHA-256 of `vips-8.18.4.tar.xz`, cross-checked against the upstream
+/// `vips-8.18.4.tar.xz.sha256sum` companion file and the GitHub release
+/// asset digest. If the pin is bumped, update this alongside the Dockerfile.
+const LIBVIPS_TARBALL_SHA256: &str =
+    "2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037";
+
+/// Test A — the recorded libvips version parses to the expected major.minor.
+///
+/// Exercises the shared parser over a sample `vips --version` line (the exact
+/// shape `provenance::libvips_version` reads from the CLI fallback) and over
+/// the already-stripped form it stores, and confirms the pin sits on the
+/// 8.18 series the bindings target.
+#[test]
+fn recorded_libvips_version_parses_to_expected_major_minor() {
+    // The pin is itself a well-formed version on the expected series.
+    let parsed = parse_libvips_major_minor(PINNED_LIBVIPS_VERSION)
+        .expect("PINNED_LIBVIPS_VERSION must parse to major.minor");
+    assert_eq!(
+        parsed,
+        (8, 18),
+        "the pinned libvips must be on the 8.18 series the bindings target (#33)"
+    );
+
+    // Raw `vips --version` output ("vips-8.18.4") parses identically to the
+    // `vips-`-stripped form provenance stores ("8.18.4").
+    assert_eq!(parse_libvips_major_minor("vips-8.18.4"), Some((8, 18)));
+    assert_eq!(parse_libvips_major_minor("8.18.4"), Some((8, 18)));
+    assert_eq!(
+        parse_libvips_major_minor("vips-8.18.4"),
+        parse_libvips_major_minor(PINNED_LIBVIPS_VERSION),
+        "the raw CLI line and the recorded pin must agree on major.minor"
+    );
+
+    // The frozen Debian oracle (#33) is a *different* series — the parser
+    // must distinguish it so the drift is detectable, not silently equal.
+    assert_eq!(parse_libvips_major_minor("vips-8.14.1"), Some((8, 14)));
+    assert_ne!(
+        parse_libvips_major_minor("vips-8.14.1"),
+        parse_libvips_major_minor(PINNED_LIBVIPS_VERSION),
+        "Debian's 8.14 must not compare equal to the 8.18 pin"
+    );
+
+    // Non-versions never masquerade as a real capture.
+    assert_eq!(parse_libvips_major_minor("unknown"), None);
+    assert_eq!(parse_libvips_major_minor(""), None);
+}
+
+/// The Dockerfile must build libvips from a pinned upstream *source* tarball,
+/// not install Debian's frozen `libvips-dev` (#33).
+#[test]
+fn dockerfile_builds_pinned_libvips_from_source() {
+    // Downloads the official upstream release tarball...
+    assert!(
+        DOCKERFILE.contains("github.com/libvips/libvips/releases/download"),
+        "Dockerfile must download the upstream libvips source tarball (#33)"
+    );
+    // ...and compiles it from source via libvips' meson/ninja build.
+    assert!(
+        DOCKERFILE.contains("meson setup") && DOCKERFILE.contains("ninja -C build install"),
+        "Dockerfile must build libvips from source via meson/ninja (#33)"
+    );
+
+    // The mismatched oracle is gone: libvips is built from source, not
+    // apt-installed as a version-pinned Debian `libvips-dev` / `libvips-tools`
+    // package. Checked against build instructions only — comments may still
+    // explain what the ~8.14 apt oracle is being replaced with.
+    let instructions = dockerfile_instructions(DOCKERFILE);
+    assert!(
+        !instructions.contains("libvips-dev=") && !instructions.contains("libvips-tools="),
+        "Dockerfile must not apt-install a version-pinned Debian libvips; that \
+         is the frozen ~8.14 oracle #33 replaces with a source build"
+    );
+}
+
+/// The libvips download must be integrity-checked before it is built: a
+/// pinned URL without a digest still trusts the remote end forever. Mirrors
+/// the PDFium checksum guard (`tests/pdfium_provenance.rs`).
+#[test]
+fn dockerfile_verifies_libvips_tarball_checksum() {
+    assert!(
+        DOCKERFILE.contains("sha256sum -c"),
+        "Dockerfile must verify the libvips tarball against a pinned SHA-256 \
+         with `sha256sum -c` (#33)"
+    );
+    assert!(
+        DOCKERFILE.contains(LIBVIPS_TARBALL_SHA256),
+        "Dockerfile is missing the pinned SHA-256 digest for \
+         vips-{PINNED_LIBVIPS_VERSION}.tar.xz (#33)"
+    );
+}
+
+/// Repo-consistency (Test B): the libvips version pinned in the Dockerfile
+/// and the version recorded in provenance/config must not silently drift.
+/// Both are committed; this reads them and compares.
+#[test]
+fn dockerfile_libvips_version_matches_recorded_provenance() {
+    let arg = dockerfile_arg(DOCKERFILE, "LIBVIPS_VERSION")
+        .expect("Dockerfile must declare `ARG LIBVIPS_VERSION=<version>`");
+    assert_eq!(
+        arg, PINNED_LIBVIPS_VERSION,
+        "Dockerfile `ARG LIBVIPS_VERSION` ({arg}) must equal \
+         `provenance::PINNED_LIBVIPS_VERSION` ({PINNED_LIBVIPS_VERSION}) so the \
+         built oracle and the recorded provenance axis cannot drift (#33)"
+    );
+
+    // The download path builds the tarball name from that same ARG (Docker
+    // expands `${LIBVIPS_VERSION}` at build time), so the URL, the pin, and
+    // the recorded axis are one value, not three that can drift apart.
+    assert!(
+        DOCKERFILE.contains("vips-${LIBVIPS_VERSION}.tar.xz"),
+        "the libvips download path must build the tarball name from \
+         `${{LIBVIPS_VERSION}}` so the URL and the pin cannot drift (#33)"
+    );
+}
+
+/// The `libvips-rs` binding must track the pinned libvips series: measuring
+/// libvips 8.18 through a different-series binding would be its own mismatch.
+/// Assert the Cargo dependency's major.minor equals the pin's.
+#[test]
+fn cargo_libvips_binding_aligns_with_pinned_version() {
+    let pin = parse_libvips_major_minor(PINNED_LIBVIPS_VERSION).unwrap();
+    let req = cargo_libvips_rs_req(CARGO_TOML)
+        .expect("Cargo.toml must declare a `libvips-rs` dependency with a version");
+    let binding = parse_libvips_major_minor(&req)
+        .expect("the libvips-rs version requirement must be a major.minor string");
+    assert_eq!(
+        binding, pin,
+        "libvips-rs binding ({req}) must track the pinned libvips series \
+         {}.{} (#33)",
+        pin.0, pin.1
+    );
+}
+
+/// The recorded pinned axis is compared against the measured version to flag
+/// a mismatched oracle (#33). Host-independent: the version strings are set
+/// explicitly rather than probed from the host libvips.
+#[test]
+fn provenance_flags_measured_vs_pinned_libvips_drift() {
+    // A pre-provenance/default fingerprint (everything "unknown") must never
+    // read as a match — a missing capture is not a hit.
+    let mut prov = Provenance::default();
+    assert!(!prov.libvips_matches_pinned());
+
+    prov.pinned_libvips_version = PINNED_LIBVIPS_VERSION.to_string();
+
+    // Measured the pinned oracle (patch may differ) → match at major.minor.
+    prov.libvips_version = "8.18.2".to_string();
+    assert!(
+        prov.libvips_matches_pinned(),
+        "same major.minor as the pin must match"
+    );
+
+    // Measured Debian's frozen 8.14 while pinned to 8.18 → the mismatched
+    // oracle #33 closes must be flagged.
+    prov.libvips_version = "8.14.1".to_string();
+    assert!(
+        !prov.libvips_matches_pinned(),
+        "an 8.14 measurement against an 8.18 pin must be flagged as drift"
+    );
+}
+
+/// Dockerfile text with `#` comment lines stripped, so *negative* assertions
+/// target build instructions rather than explanatory prose (a comment may
+/// still name the ~8.14 apt oracle the source build replaces).
+fn dockerfile_instructions(dockerfile: &str) -> String {
+    dockerfile
+        .lines()
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Extract the default value of `ARG <name>=<value>` from Dockerfile text.
+fn dockerfile_arg(dockerfile: &str, name: &str) -> Option<String> {
+    let needle = format!("ARG {name}=");
+    dockerfile
+        .lines()
+        .find_map(|line| line.trim().strip_prefix(&needle))
+        .map(|value| {
+            value
+                .split_whitespace()
+                .next()
+                .unwrap_or(value)
+                .trim()
+                .to_string()
+        })
+}
+
+/// Pull the version requirement string out of the `libvips-rs` dependency
+/// line in a Cargo manifest, stripping any leading semver comparator so a
+/// tightened `~8.18` / `=8.18.4` still parses to major.minor.
+fn cargo_libvips_rs_req(cargo: &str) -> Option<String> {
+    let line = cargo
+        .lines()
+        .find(|line| line.trim_start().starts_with("libvips-rs"))?;
+    let start = line.find('"')? + 1;
+    let end = line[start..].find('"')? + start;
+    Some(
+        line[start..end]
+            .trim_start_matches(['=', '^', '~', '>', '<', ' '])
+            .to_string(),
+    )
+}

--- a/tests/libvips_provenance.rs
+++ b/tests/libvips_provenance.rs
@@ -15,16 +15,13 @@
 //! regresses to an unpinned / apt-installed libvips — without needing Docker
 //! or libvips in the loop.
 
-use libviprs_bench::provenance::{PINNED_LIBVIPS_VERSION, Provenance, parse_libvips_major_minor};
+use libviprs_bench::provenance::{
+    OracleMatch, PINNED_LIBVIPS_SHA256, PINNED_LIBVIPS_VERSION, Provenance,
+    parse_libvips_major_minor,
+};
 
 const DOCKERFILE: &str = include_str!("../Dockerfile");
 const CARGO_TOML: &str = include_str!("../Cargo.toml");
-
-/// SHA-256 of `vips-8.18.4.tar.xz`, cross-checked against the upstream
-/// `vips-8.18.4.tar.xz.sha256sum` companion file and the GitHub release
-/// asset digest. If the pin is bumped, update this alongside the Dockerfile.
-const LIBVIPS_TARBALL_SHA256: &str =
-    "2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037";
 
 /// Test A — the recorded libvips version parses to the expected major.minor.
 ///
@@ -105,8 +102,9 @@ fn dockerfile_verifies_libvips_tarball_checksum() {
          with `sha256sum -c` (#33)"
     );
     assert!(
-        DOCKERFILE.contains(LIBVIPS_TARBALL_SHA256),
-        "Dockerfile is missing the pinned SHA-256 digest for \
+        DOCKERFILE.contains(PINNED_LIBVIPS_SHA256),
+        "Dockerfile is missing the pinned SHA-256 digest \
+         (`provenance::PINNED_LIBVIPS_SHA256`) for \
          vips-{PINNED_LIBVIPS_VERSION}.tar.xz (#33)"
     );
 }
@@ -178,6 +176,77 @@ fn provenance_flags_measured_vs_pinned_libvips_drift() {
     assert!(
         !prov.libvips_matches_pinned(),
         "an 8.14 measurement against an 8.18 pin must be flagged as drift"
+    );
+}
+
+/// The richer [`OracleMatch`] classification distinguishes a genuine
+/// mismatched oracle (both sides parse and differ) from an indeterminate
+/// capture (either side `"unknown"`), so a consumer can warn loudly on the
+/// former without crying wolf on the latter (#33).
+#[test]
+fn oracle_match_classifies_mismatch_vs_indeterminate() {
+    // Default fingerprint: both sides "unknown" → indeterminate, not a match.
+    let mut prov = Provenance::default();
+    assert_eq!(prov.libvips_oracle_match(), OracleMatch::Indeterminate);
+    assert!(!prov.libvips_matches_pinned());
+
+    prov.pinned_libvips_version = PINNED_LIBVIPS_VERSION.to_string();
+
+    // Only the measured side unknown (a host run with no libvips) → still
+    // indeterminate: the guard must not raise a false mismatch alarm.
+    assert_eq!(prov.libvips_oracle_match(), OracleMatch::Indeterminate);
+
+    // Same major.minor as the pin (patch may differ) → match.
+    prov.libvips_version = "8.18.2".to_string();
+    assert_eq!(prov.libvips_oracle_match(), OracleMatch::Match);
+    assert!(prov.libvips_matches_pinned());
+
+    // Debian's 8.14 against the 8.18 pin → a concrete mismatch carrying both
+    // parsed series, so a consumer can render the exact versions.
+    prov.libvips_version = "8.14.1".to_string();
+    assert_eq!(
+        prov.libvips_oracle_match(),
+        OracleMatch::Mismatch {
+            measured: (8, 14),
+            pinned: (8, 18),
+        }
+    );
+    assert!(!prov.libvips_matches_pinned());
+}
+
+/// The build must force-enable the hot-path codecs rather than leave them to
+/// meson's `auto` detection, so a missing codec `-dev` library hard-fails the
+/// build instead of silently yielding a codec-less oracle — a PNG-less libvips
+/// would quietly invalidate the DeepZoom PNG-tile hot path (#33).
+#[test]
+fn dockerfile_force_enables_hot_path_codecs() {
+    for opt in [
+        "-Dpng=enabled",
+        "-Djpeg=enabled",
+        "-Dtiff=enabled",
+        "-Dwebp=enabled",
+    ] {
+        assert!(
+            DOCKERFILE.contains(opt),
+            "Dockerfile must force-enable the codec with `{opt}` so a missing \
+             library fails the build instead of silently disabling the format (#33)"
+        );
+    }
+}
+
+/// The post-build check must assert the discoverable libvips is *exactly* the
+/// pinned version and fail the build otherwise — merely printing the version
+/// (the pre-review behaviour) would let a stray/wrong libvips ahead on PATH
+/// build green (#33).
+#[test]
+fn dockerfile_asserts_built_libvips_version_equals_pin() {
+    let instructions = dockerfile_instructions(DOCKERFILE);
+    assert!(
+        instructions.contains("pkg-config --modversion vips")
+            && instructions.contains("${LIBVIPS_VERSION}")
+            && instructions.contains("exit 1"),
+        "Dockerfile must compare `pkg-config --modversion vips` against \
+         ${{LIBVIPS_VERSION}} and `exit 1` on mismatch, not just print it (#33)"
     );
 }
 


### PR DESCRIPTION
Resolves **#24** and sub-issue **#33** — replaces Debian's frozen ~8.14 apt libvips (a mismatched/unfair oracle vs the 8.18 bindings) with a checksum-pinned build of libvips 8.18.4 from source, and makes the measured-vs-pinned libvips version a recorded + **enforced** provenance axis (stderr WARNING on drift in report/scalability/cross_version).

TDD: commit 1 adds failing `tests/libvips_provenance.rs`; commit 2 implements. 4-expert review applied in a follow-up commit (consolidated in a comment below). Follow-ups filed: #35 (apt/base digest pinning), #36 (periodic upstream-SHA/docker-build validation).

Local gate (GitHub CI intentionally skipped via [skip ci]): cargo check ×4 feature cells, clippy --features libvips -D warnings, test --features libvips (lib+integration+doc), fmt — all green.

Closes #24
Closes #33