### PR TITLE
report: size streaming/mapreduce budget so large cells don't panic (#38)

### DIFF
--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -20,7 +20,7 @@ use libviprs::{
     CollectingObserver, EngineBuilder, EngineConfig, EngineEvent, EngineKind, Layout, MemorySink,
     PyramidPlanner, RasterStripSource,
 };
-use libviprs_bench::gradient_raster;
+use libviprs_bench::{gradient_raster, streaming_budget_for};
 use std::sync::Arc;
 
 const WIDTH: u32 = 4096;
@@ -126,6 +126,13 @@ fn main() {
     let planner = PyramidPlanner::new(WIDTH, HEIGHT, TILE_SIZE, 0, Layout::DeepZoom).unwrap();
     let plan = planner.plan();
 
+    // Size the streaming/mapreduce budget to admit the worst-case tile-aligned
+    // strip at this 4096-wide canvas: a flat 1 MB trips `BudgetPolicy::Error`'s
+    // `BudgetExceeded` up front (worst-case strip = 4096·512·3 = 6.29 MB) and
+    // `.run().unwrap()` would panic — the exact failure mode issue #38 fixes.
+    // RGB8 gradient, so bpp = 3; shared with the report/scalability paths.
+    let budget = streaming_budget_for(1_000_000, plan.canvas_width, TILE_SIZE, 3);
+
     println!("Image: {WIDTH}x{HEIGHT}, tile_size={TILE_SIZE}");
     println!(
         "Plan: {} levels, {} tiles",
@@ -175,7 +182,7 @@ fn main() {
         let result = EngineBuilder::new(strip_src, plan.clone(), &sink)
             .with_engine(EngineKind::Streaming)
             .with_config(EngineConfig::default())
-            .with_memory_budget(1_000_000)
+            .with_memory_budget(budget)
             .with_budget_policy(BudgetPolicy::Error)
             .with_observer_arc(observer.clone())
             .run()
@@ -216,7 +223,7 @@ fn main() {
         let result = EngineBuilder::new(strip_src, plan.clone(), &sink)
             .with_engine(EngineKind::MapReduce)
             .with_config(EngineConfig::default().with_concurrency(0))
-            .with_memory_budget(1_000_000)
+            .with_memory_budget(budget)
             .with_budget_policy(BudgetPolicy::Error)
             .with_observer_arc(observer.clone())
             .run()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,12 @@ pub struct BenchmarkSnapshot {
     pub timestamp: String,
     /// Tile size used.
     pub tile_size: u32,
-    /// Memory budget used for streaming/mapreduce engines.
+    /// Requested streaming/mapreduce budget FLOOR (the report's configured
+    /// [`BENCH_STREAMING_BUDGET`]), not the budget any single run actually used.
+    /// The effective budget is sized up per canvas width by
+    /// [`streaming_budget_for`] (issue #38), so cross-size rows are NOT under one
+    /// identical budget; each run's effective figure lives in
+    /// [`RunMetrics::memory_budget_bytes`].
     pub memory_budget_bytes: u64,
     /// Individual run metrics.
     pub runs: Vec<RunMetrics>,
@@ -180,7 +185,12 @@ pub struct RunMetrics {
     pub inflight_strips: u32,
     /// Concurrency level used.
     pub concurrency: usize,
-    /// Memory budget in bytes (streaming/mapreduce only, 0 for monolithic).
+    /// EFFECTIVE memory budget the engine actually ran with, in bytes
+    /// (streaming/mapreduce only, 0 for monolithic). This is the per-run figure
+    /// after [`streaming_budget_for`] raised the requested floor to admit the
+    /// worst-case tile-aligned strip at this canvas width (issue #38), so it is
+    /// size-dependent and generally exceeds the report's flat floor (the
+    /// [`BenchmarkSnapshot`] `memory_budget_bytes`).
     pub memory_budget_bytes: u64,
 }
 
@@ -421,28 +431,45 @@ pub fn bench_monolithic(
 }
 
 /// Size a streaming / mapreduce memory budget so the worst-case tile-aligned
-/// strip (`width × 2·tile_size × bpp`) always fits under the strict
-/// [`BudgetPolicy::Error`] these engines run with.
+/// strip always fits under the strict [`BudgetPolicy::Error`] these engines run
+/// with — sized from the SAME input the engines' pre-flight gates on:
+/// `canvas_width × 2·tile_size × bpp`.
 ///
 /// The streaming and mapreduce engines reject a run up front with
 /// `BudgetExceeded` when even one minimum aligned strip (`2 × tile_size` rows at
-/// canvas width) cannot fit the budget, so a flat budget that is fine for small
-/// canvases (the report's [`BENCH_STREAMING_BUDGET`]) starves every image from
-/// 1024 px up. `requested` is treated as a floor and raised only when a wider
-/// canvas needs more, mirroring the `scalability` binary's own
-/// `streaming_budget_for` and the pdfium path in `bench_streaming_pdf`. The `2×`
-/// over the minimum aligned strip leaves headroom for the per-level accumulator
-/// chain.
+/// canvas width) cannot fit the budget (`libviprs::streaming` /
+/// `streaming_mapreduce`), so a flat budget that is fine for small canvases (the
+/// report's [`BENCH_STREAMING_BUDGET`]) starves every image from 1024 px up.
+/// `floor` is a lower bound, raised only when a wider canvas needs more.
 ///
-/// Saturating arithmetic throughout: an adversarial `width` / `tile_size`
-/// saturates the budget large — which the engine then rejects cleanly rather
-/// than being handed a wrapped-small budget — instead of overflowing (a debug
-/// panic / release wraparound).
-pub fn streaming_budget_for(requested: u64, width: u32, tile_size: u32, bpp: u64) -> u64 {
-    let min_strip_bytes = (width as u64)
+/// Pass the plan's [`canvas_width`](PyramidPlan::canvas_width), NOT the source
+/// width: the engines gate on the canvas, and for a centred/padded plan the
+/// canvas is wider than the image (`canvas_width = top_cols × tile_size`), so
+/// sizing from the source width would under-budget the exact strip the engine
+/// checks (issue #38 review). This is the single sizing helper shared by every
+/// streaming-family bench path — the raster [`bench_streaming`] /
+/// [`bench_mapreduce`], the candidate builder [`write_libviprs_pyramid`], the
+/// pdfium `bench_streaming_pdf`, and the `scalability` / `flamegraph` binaries.
+///
+/// The `2×` over the single-strip pre-flight minimum is a fixed benchmark
+/// margin: it clears the strict pre-flight gate (the only enforced
+/// `BudgetExceeded` source for raster streaming) with 100% slack. It is
+/// deliberately NOT the full per-level working-set estimate
+/// ([`PyramidPlan::estimate_streaming_peak_memory`](libviprs::PyramidPlan)),
+/// which is strictly larger (the lower levels plus the 10% margin are unfunded);
+/// under this budget `compute_strip_height` returns `None` and the engine runs
+/// at its minimum aligned strip (`2·tile_size`) — the true-streaming regime this
+/// benchmark exists to characterize.
+///
+/// Saturating arithmetic keeps the helper total and panic-free. No constructible
+/// [`PyramidPlan`] reaches magnitudes that would overflow (the planner's
+/// `checked_canvas_bounds` rejects them), so the saturation is purely defensive.
+#[must_use]
+pub fn streaming_budget_for(floor: u64, canvas_width: u32, tile_size: u32, bpp: u32) -> u64 {
+    let min_strip_bytes = (canvas_width as u64)
         .saturating_mul(2u64.saturating_mul(tile_size as u64))
-        .saturating_mul(bpp);
-    requested.max(min_strip_bytes.saturating_mul(2))
+        .saturating_mul(bpp as u64);
+    floor.max(min_strip_bytes.saturating_mul(2))
 }
 
 /// Run the streaming engine and collect metrics.
@@ -455,12 +482,13 @@ pub fn bench_streaming(
 ) -> RunMetrics {
     // Size the budget to admit the worst-case tile-aligned strip so the strict
     // `BudgetPolicy::Error` never trips on a large canvas; the flat report
-    // budget alone starves every image from 1024 px up (issue #38).
+    // budget alone starves every image from 1024 px up (issue #38). Size from
+    // `plan.canvas_width` — the exact width the engine's pre-flight gates on.
     let budget = streaming_budget_for(
         memory_budget_bytes,
-        src.width(),
+        plan.canvas_width,
         plan.tile_size,
-        src.format().bytes_per_pixel() as u64,
+        src.format().bytes_per_pixel() as u32,
     );
     let out_dir = fs_sink_dir(label);
     let sink = engine_fs_sink(&out_dir, plan);
@@ -520,14 +548,15 @@ pub fn bench_mapreduce(
 ) -> RunMetrics {
     // Size the budget to admit the worst-case tile-aligned strip so the strict
     // `BudgetPolicy::Error` never trips on a large canvas; the flat report
-    // budget alone starves every image from 1024 px up (issue #38). The sized
-    // budget is what the engine runs with, so the strip-height and in-flight
-    // accounting below is computed against it too.
+    // budget alone starves every image from 1024 px up (issue #38). Size from
+    // `plan.canvas_width` — the exact width the engine's pre-flight gates on.
+    // The sized budget is what the engine runs with, so the strip-height and
+    // in-flight accounting below is computed against it too.
     let budget = streaming_budget_for(
         memory_budget_bytes,
-        src.width(),
+        plan.canvas_width,
         plan.tile_size,
-        src.format().bytes_per_pixel() as u64,
+        src.format().bytes_per_pixel() as u32,
     );
     let out_dir = fs_sink_dir(label);
     let sink = engine_fs_sink(&out_dir, plan);
@@ -712,12 +741,13 @@ pub fn bench_streaming_pdf(
     // Admit the worst-case tile-aligned strip so `BudgetPolicy::Error` never
     // trips on the wide RGBA pdfium strips (4-bpp here, wider than the 3-bpp
     // gradient at the same width). Shared with the raster `bench_streaming` /
-    // `bench_mapreduce` path via `streaming_budget_for` (saturating).
+    // `bench_mapreduce` path via `streaming_budget_for` (saturating), sized from
+    // `plan.canvas_width` — the width the engine's pre-flight gates on.
     let budget = streaming_budget_for(
         memory_budget_bytes,
-        width,
-        tile_size,
-        source.format().bytes_per_pixel() as u64,
+        plan.canvas_width,
+        plan.tile_size,
+        source.format().bytes_per_pixel() as u32,
     );
 
     let out_dir = fs_sink_dir(label);
@@ -813,10 +843,13 @@ pub fn write_temp_png(src: &Raster) -> std::path::PathBuf {
 ///
 /// Parameterized over [`EngineKind`] so the output-equivalence spot-check can
 /// validate **each** libviprs engine's own pixels (not just the monolithic
-/// engine's) at the concurrency actually benchmarked. `budget_bytes` bounds the
-/// streaming / mapreduce engines (ignored by the monolithic engine), mirroring
-/// the timed `bench_*` paths so the candidate is built the same way it is
-/// measured.
+/// engine's) at the concurrency actually benchmarked. `budget_bytes` is the
+/// budget FLOOR for the streaming / mapreduce engines (ignored by the monolithic
+/// engine); it is sized up per canvas via [`streaming_budget_for`] exactly as
+/// the timed `bench_*` paths do, so the candidate is built under the identical
+/// budget its timed row ran with. Without that sizing the raw floor (the
+/// report's 1 MB) trips `BudgetExceeded` at every size >= 1024 px and the
+/// spot-check silently degrades to "no score" (issue #38 review).
 ///
 /// Unlike the `bench_*` functions this does **not** delete its output — the
 /// caller owns `dir`. It exists for the pixel-level output-equivalence
@@ -842,10 +875,19 @@ pub fn write_libviprs_pyramid(
         .with_config(EngineConfig::default().with_concurrency(concurrency))
         .with_observer_arc(observer);
     // The streaming / mapreduce engines are budget-driven; bound them exactly
-    // as their timed `bench_*` paths do. The monolithic engine ignores it.
+    // as their timed `bench_*` paths do — size the floor up to admit the
+    // worst-case tile-aligned strip so the strict `BudgetPolicy::Error` does not
+    // trip on a large canvas and silently skip the spot-check (issue #38
+    // review). The monolithic engine ignores the budget.
     if matches!(engine, EngineKind::Streaming | EngineKind::MapReduce) {
+        let budget = streaming_budget_for(
+            budget_bytes,
+            plan.canvas_width,
+            plan.tile_size,
+            src.format().bytes_per_pixel() as u32,
+        );
         builder = builder
-            .with_memory_budget(budget_bytes)
+            .with_memory_budget(budget)
             .with_budget_policy(BudgetPolicy::Error);
     }
     builder
@@ -2143,47 +2185,82 @@ mod budget_tests {
     use super::*;
 
     /// From 1024 px up the worst-case tile-aligned strip
-    /// (`width × 2·tile_size × bpp`) exceeds the report's flat 1 MB budget, so
-    /// [`streaming_budget_for`] must raise it to admit that strip (with the 2×
-    /// accumulator headroom) rather than let `BudgetPolicy::Error` trip.
+    /// (`canvas_width × 2·tile_size × bpp`) exceeds the report's flat 1 MB
+    /// budget, so [`streaming_budget_for`] must raise it to admit that strip
+    /// (at 2× the single-strip pre-flight minimum) rather than let
+    /// `BudgetPolicy::Error` trip.
     #[test]
     fn sized_budget_admits_worst_case_strip_at_large_width() {
-        let requested = BENCH_STREAMING_BUDGET; // 1 MB, the report default
+        let floor = BENCH_STREAMING_BUDGET; // 1 MB, the report default
         let tile = BENCH_TILE_SIZE; // 256
-        let bpp: u64 = 3; // RGB8 gradient
+        let bpp: u32 = 3; // RGB8 gradient
         let width: u32 = 1024;
-        let worst_case = width as u64 * 2 * tile as u64 * bpp;
+        let worst_case = width as u64 * 2 * tile as u64 * bpp as u64;
         // Premise: the flat budget really is too small at this width.
         assert!(
-            worst_case > requested,
+            worst_case > floor,
             "test premise: 1024px worst-case strip must exceed the flat budget"
         );
-        let budget = streaming_budget_for(requested, width, tile, bpp);
+        let budget = streaming_budget_for(floor, width, tile, bpp);
         assert!(
             budget >= worst_case,
             "sized budget {budget} must admit the worst-case strip {worst_case}"
         );
-        // Exactly the 2× headroom over the minimum aligned strip.
+        // Exactly 2× the minimum aligned strip (the fixed pre-flight margin).
         assert_eq!(budget, worst_case * 2);
     }
 
     /// A small canvas whose worst-case strip already fits keeps the caller's
-    /// requested budget as the floor — the budget is raised, never lowered.
+    /// requested floor — the budget is raised, never lowered.
     #[test]
     fn small_canvas_keeps_requested_floor() {
-        let requested = BENCH_STREAMING_BUDGET;
+        let floor = BENCH_STREAMING_BUDGET;
         // 256px RGB8 at tile 256: worst-case = 256·512·3 = 393_216; 2× =
         // 786_432, still under the 1 MB floor.
-        let budget = streaming_budget_for(requested, 256, BENCH_TILE_SIZE, 3);
-        assert_eq!(
-            budget, requested,
-            "floor must win when the strip already fits"
-        );
+        let budget = streaming_budget_for(floor, 256, BENCH_TILE_SIZE, 3);
+        assert_eq!(budget, floor, "floor must win when the strip already fits");
         assert!(budget >= 256u64 * 2 * BENCH_TILE_SIZE as u64 * 3);
     }
 
-    /// Adversarial dimensions saturate the budget large (which the engine then
-    /// rejects cleanly) rather than overflowing to a wrapped-small value.
+    /// The helper sizes from the CANVAS width it is handed, and the callers hand
+    /// it `plan.canvas_width` (not the source width) so it reproduces the input
+    /// the engine's pre-flight gates on. A centred plan widens the canvas past a
+    /// tile-unaligned source, so sizing from the canvas yields a strictly larger
+    /// budget than sizing from the source width would — this pins why the call
+    /// sites must pass `plan.canvas_width` (issue #38 review).
+    #[test]
+    fn budget_tracks_canvas_width_not_source_width() {
+        let img_w: u32 = 1000; // deliberately not a multiple of the tile size
+        let plan = PyramidPlanner::new(img_w, 1000, BENCH_TILE_SIZE, 0, libviprs::Layout::DeepZoom)
+            .expect("plan")
+            .with_centre(true)
+            .plan();
+        assert!(
+            plan.canvas_width > img_w,
+            "a centred plan pads a tile-unaligned canvas wider than the image \
+             ({} vs {img_w})",
+            plan.canvas_width
+        );
+        let floor = BENCH_STREAMING_BUDGET;
+        let from_canvas = streaming_budget_for(floor, plan.canvas_width, plan.tile_size, 3);
+        let from_source = streaming_budget_for(floor, img_w, plan.tile_size, 3);
+        assert!(
+            from_canvas >= from_source,
+            "canvas-sized budget {from_canvas} must be >= source-sized {from_source}"
+        );
+        // The canvas-sized budget admits the strip the engine actually checks.
+        let engine_gate = plan.canvas_width as u64 * 2 * plan.tile_size as u64 * 3;
+        assert!(
+            from_canvas >= engine_gate,
+            "canvas-sized budget {from_canvas} must admit the engine gate strip \
+             {engine_gate}"
+        );
+    }
+
+    /// Adversarial dimensions saturate the budget large rather than overflowing
+    /// to a wrapped-small value. (No constructible [`PyramidPlan`] reaches these
+    /// magnitudes — the planner rejects them — so the saturation is purely
+    /// defensive, keeping the helper total.)
     #[test]
     fn adversarial_dimensions_saturate_not_wrap() {
         let budget = streaming_budget_for(BENCH_STREAMING_BUDGET, u32::MAX, u32::MAX, 4);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,6 +420,31 @@ pub fn bench_monolithic(
     }
 }
 
+/// Size a streaming / mapreduce memory budget so the worst-case tile-aligned
+/// strip (`width × 2·tile_size × bpp`) always fits under the strict
+/// [`BudgetPolicy::Error`] these engines run with.
+///
+/// The streaming and mapreduce engines reject a run up front with
+/// `BudgetExceeded` when even one minimum aligned strip (`2 × tile_size` rows at
+/// canvas width) cannot fit the budget, so a flat budget that is fine for small
+/// canvases (the report's [`BENCH_STREAMING_BUDGET`]) starves every image from
+/// 1024 px up. `requested` is treated as a floor and raised only when a wider
+/// canvas needs more, mirroring the `scalability` binary's own
+/// `streaming_budget_for` and the pdfium path in `bench_streaming_pdf`. The `2×`
+/// over the minimum aligned strip leaves headroom for the per-level accumulator
+/// chain.
+///
+/// Saturating arithmetic throughout: an adversarial `width` / `tile_size`
+/// saturates the budget large — which the engine then rejects cleanly rather
+/// than being handed a wrapped-small budget — instead of overflowing (a debug
+/// panic / release wraparound).
+pub fn streaming_budget_for(requested: u64, width: u32, tile_size: u32, bpp: u64) -> u64 {
+    let min_strip_bytes = (width as u64)
+        .saturating_mul(2u64.saturating_mul(tile_size as u64))
+        .saturating_mul(bpp);
+    requested.max(min_strip_bytes.saturating_mul(2))
+}
+
 /// Run the streaming engine and collect metrics.
 pub fn bench_streaming(
     src: &Raster,
@@ -428,6 +453,15 @@ pub fn bench_streaming(
     memory_budget_bytes: u64,
     label: &str,
 ) -> RunMetrics {
+    // Size the budget to admit the worst-case tile-aligned strip so the strict
+    // `BudgetPolicy::Error` never trips on a large canvas; the flat report
+    // budget alone starves every image from 1024 px up (issue #38).
+    let budget = streaming_budget_for(
+        memory_budget_bytes,
+        src.width(),
+        plan.tile_size,
+        src.format().bytes_per_pixel() as u64,
+    );
     let out_dir = fs_sink_dir(label);
     let sink = engine_fs_sink(&out_dir, plan);
     let observer = Arc::new(CollectingObserver::new());
@@ -437,7 +471,7 @@ pub fn bench_streaming(
     let result = EngineBuilder::new(strip_src, plan.clone(), &sink)
         .with_engine(EngineKind::Streaming)
         .with_config(engine_config)
-        .with_memory_budget(memory_budget_bytes)
+        .with_memory_budget(budget)
         .with_budget_policy(BudgetPolicy::Error)
         .with_observer_arc(observer.clone())
         .run()
@@ -472,7 +506,7 @@ pub fn bench_streaming(
         batches: 0,
         inflight_strips: 0,
         concurrency,
-        memory_budget_bytes,
+        memory_budget_bytes: budget,
     }
 }
 
@@ -484,6 +518,17 @@ pub fn bench_mapreduce(
     memory_budget_bytes: u64,
     label: &str,
 ) -> RunMetrics {
+    // Size the budget to admit the worst-case tile-aligned strip so the strict
+    // `BudgetPolicy::Error` never trips on a large canvas; the flat report
+    // budget alone starves every image from 1024 px up (issue #38). The sized
+    // budget is what the engine runs with, so the strip-height and in-flight
+    // accounting below is computed against it too.
+    let budget = streaming_budget_for(
+        memory_budget_bytes,
+        src.width(),
+        plan.tile_size,
+        src.format().bytes_per_pixel() as u64,
+    );
     let out_dir = fs_sink_dir(label);
     let sink = engine_fs_sink(&out_dir, plan);
     let observer = Arc::new(CollectingObserver::new());
@@ -497,7 +542,7 @@ pub fn bench_mapreduce(
     let result = EngineBuilder::new(strip_src, plan.clone(), &sink)
         .with_engine(EngineKind::MapReduce)
         .with_config(engine_config)
-        .with_memory_budget(memory_budget_bytes)
+        .with_memory_budget(budget)
         .with_budget_policy(BudgetPolicy::Error)
         .with_observer_arc(observer.clone())
         .run()
@@ -516,8 +561,8 @@ pub fn bench_mapreduce(
         .iter()
         .filter(|e| matches!(e, EngineEvent::BatchStarted { .. }))
         .count() as u32;
-    let strip_height = libviprs::compute_strip_height(plan, src.format(), memory_budget_bytes)
-        .unwrap_or(2 * plan.tile_size);
+    let strip_height =
+        libviprs::compute_strip_height(plan, src.format(), budget).unwrap_or(2 * plan.tile_size);
     // Mirror the engine's own channel-backlog charge so the reported
     // in-flight strip count matches what the MapReduce engine actually
     // budgets for (libviprs `streaming_mapreduce`): the parallel emitter
@@ -535,7 +580,7 @@ pub fn bench_mapreduce(
         src.format(),
         strip_height,
         channel_bytes,
-        memory_budget_bytes,
+        budget,
     );
 
     RunMetrics {
@@ -557,7 +602,7 @@ pub fn bench_mapreduce(
         batches,
         inflight_strips: inflight,
         concurrency: tile_concurrency,
-        memory_budget_bytes,
+        memory_budget_bytes: budget,
     }
 }
 
@@ -665,15 +710,15 @@ pub fn bench_streaming_pdf(
     let plan = planner.plan();
 
     // Admit the worst-case tile-aligned strip so `BudgetPolicy::Error` never
-    // trips on the wide RGBA pdfium strips. Saturating arithmetic so an
-    // adversarial page width or `tile_size` saturates the budget large (which
-    // the engine then rejects cleanly) instead of wrapping small in release or
-    // panicking in debug.
-    let bpp = source.format().bytes_per_pixel() as u64;
-    let min_strip_bytes = (width as u64)
-        .saturating_mul(2u64.saturating_mul(tile_size as u64))
-        .saturating_mul(bpp);
-    let budget = memory_budget_bytes.max(min_strip_bytes.saturating_mul(2));
+    // trips on the wide RGBA pdfium strips (4-bpp here, wider than the 3-bpp
+    // gradient at the same width). Shared with the raster `bench_streaming` /
+    // `bench_mapreduce` path via `streaming_budget_for` (saturating).
+    let budget = streaming_budget_for(
+        memory_budget_bytes,
+        width,
+        tile_size,
+        source.format().bytes_per_pixel() as u64,
+    );
 
     let out_dir = fs_sink_dir(label);
     let sink = engine_fs_sink(&out_dir, &plan);
@@ -2090,5 +2135,66 @@ mod history_tests {
         assert_eq!(snap.version, core_version());
         assert_eq!(snap.git_sha, core_git_sha());
         assert!(!snap.version.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod budget_tests {
+    use super::*;
+
+    /// From 1024 px up the worst-case tile-aligned strip
+    /// (`width × 2·tile_size × bpp`) exceeds the report's flat 1 MB budget, so
+    /// [`streaming_budget_for`] must raise it to admit that strip (with the 2×
+    /// accumulator headroom) rather than let `BudgetPolicy::Error` trip.
+    #[test]
+    fn sized_budget_admits_worst_case_strip_at_large_width() {
+        let requested = BENCH_STREAMING_BUDGET; // 1 MB, the report default
+        let tile = BENCH_TILE_SIZE; // 256
+        let bpp: u64 = 3; // RGB8 gradient
+        let width: u32 = 1024;
+        let worst_case = width as u64 * 2 * tile as u64 * bpp;
+        // Premise: the flat budget really is too small at this width.
+        assert!(
+            worst_case > requested,
+            "test premise: 1024px worst-case strip must exceed the flat budget"
+        );
+        let budget = streaming_budget_for(requested, width, tile, bpp);
+        assert!(
+            budget >= worst_case,
+            "sized budget {budget} must admit the worst-case strip {worst_case}"
+        );
+        // Exactly the 2× headroom over the minimum aligned strip.
+        assert_eq!(budget, worst_case * 2);
+    }
+
+    /// A small canvas whose worst-case strip already fits keeps the caller's
+    /// requested budget as the floor — the budget is raised, never lowered.
+    #[test]
+    fn small_canvas_keeps_requested_floor() {
+        let requested = BENCH_STREAMING_BUDGET;
+        // 256px RGB8 at tile 256: worst-case = 256·512·3 = 393_216; 2× =
+        // 786_432, still under the 1 MB floor.
+        let budget = streaming_budget_for(requested, 256, BENCH_TILE_SIZE, 3);
+        assert_eq!(
+            budget, requested,
+            "floor must win when the strip already fits"
+        );
+        assert!(budget >= 256u64 * 2 * BENCH_TILE_SIZE as u64 * 3);
+    }
+
+    /// Adversarial dimensions saturate the budget large (which the engine then
+    /// rejects cleanly) rather than overflowing to a wrapped-small value.
+    #[test]
+    fn adversarial_dimensions_saturate_not_wrap() {
+        let budget = streaming_budget_for(BENCH_STREAMING_BUDGET, u32::MAX, u32::MAX, 4);
+        assert_eq!(
+            budget,
+            u64::MAX,
+            "adversarial size must saturate the budget"
+        );
+        assert!(
+            budget >= BENCH_STREAMING_BUDGET,
+            "a saturated budget is never below the requested floor"
+        );
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -95,7 +95,11 @@ fn main() {
         );
     }
     println!();
-    println!("Tile size: {tile_size}, memory budget: {streaming_budget} bytes");
+    println!(
+        "Tile size: {tile_size}, streaming/mapreduce budget floor: {streaming_budget} bytes \
+         (auto-scaled per width to admit the worst-case tile-aligned strip, so cross-size rows \
+         are not under one identical budget — see each row's effective budget in the JSON)"
+    );
     println!("Iterations: {iters} timed + {warmup} warm-up per cell (child-isolated)");
     println!(
         "Image sizes: {:?}",
@@ -190,7 +194,8 @@ fn main() {
         "libviprs engine comparison benchmark (monolithic / streaming / mapreduce)\n\
          measured libviprs core: {} ({})\n\
          bench harness: {}\n\
-         Tile size: {tile_size}, memory budget: {streaming_budget} bytes\n\n",
+         Tile size: {tile_size}, streaming/mapreduce budget floor: {streaming_budget} bytes \
+         (auto-scaled per width; per-row effective budget in benchmark_results.json)\n\n",
         core_version(),
         core_git_sha(),
         env!("CARGO_PKG_VERSION"),

--- a/src/scalability.rs
+++ b/src/scalability.rs
@@ -64,7 +64,6 @@ const TILE_SIZE: u32 = 256;
 /// width here is identical to sizing from `plan.canvas_width` (RGB8, bpp = 3).
 const STREAMING_BUDGET_FLOOR: u64 = 4_000_000; // 4 MB
 
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ScalabilityPoint {
     width: u32,

--- a/src/scalability.rs
+++ b/src/scalability.rs
@@ -30,7 +30,9 @@ use libviprs::{
     RasterStripSource, TileFormat,
 };
 use libviprs_bench::provenance::{OracleMatch, Provenance};
-use libviprs_bench::{bench_libvips, gradient_raster, vips_available, write_temp_png};
+use libviprs_bench::{
+    bench_libvips, gradient_raster, streaming_budget_for, vips_available, write_temp_png,
+};
 
 /// Peak RSS of the current process in bytes. Mirrors the RSS basis the
 /// libvips paths report so the scalability charts compare like-for-like
@@ -54,19 +56,14 @@ fn process_peak_rss() -> u64 {
 }
 
 const TILE_SIZE: u32 = 256;
-/// Floor on the streaming engine's memory budget. Keeps small images in
-/// the "true streaming" regime; large images need more (computed below).
+/// Floor on the streaming engine's memory budget, passed as the `floor` to the
+/// shared [`streaming_budget_for`]. Keeps small images in the "true streaming"
+/// regime; wider canvases are auto-scaled up so at least one tile-aligned strip
+/// fits and the strict `BudgetPolicy::Error` never trips. This binary's non-
+/// centred DeepZoom plans have `canvas_width == width`, so passing the image
+/// width here is identical to sizing from `plan.canvas_width` (RGB8, bpp = 3).
 const STREAMING_BUDGET_FLOOR: u64 = 4_000_000; // 4 MB
 
-/// Compute the per-image streaming budget. The floor `STREAMING_BUDGET_FLOOR`
-/// keeps small images in the streaming regime; for wider canvases we need
-/// at least one tile-aligned strip (`min strip = 2 × tile_size`) to fit,
-/// otherwise `BudgetPolicy::Error` (intentionally strict) trips. The
-/// 2× multiplier leaves headroom for the per-level accumulator chain.
-fn streaming_budget_for(width: u32, tile_size: u32) -> u64 {
-    let min_strip_bytes = (width as u64) * (tile_size as u64) * 2 * 3;
-    (min_strip_bytes * 2).max(STREAMING_BUDGET_FLOOR)
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ScalabilityPoint {
@@ -591,7 +588,7 @@ fn main() {
 
             // Streaming + MapReduce share a budget chosen per-width so the
             // tile-aligned minimum strip always fits.
-            let budget = streaming_budget_for(w, TILE_SIZE);
+            let budget = streaming_budget_for(STREAMING_BUDGET_FLOOR, w, TILE_SIZE, 3);
 
             // Streaming
             let run = run_streaming(&src, TILE_SIZE, budget, conc);
@@ -743,7 +740,8 @@ fn main() {
             largest.0,
             largest.1,
             largest_mp,
-            streaming_budget_for(largest.0, TILE_SIZE) as f64 / (1024.0 * 1024.0),
+            streaming_budget_for(STREAMING_BUDGET_FLOOR, largest.0, TILE_SIZE, 3) as f64
+                / (1024.0 * 1024.0),
         );
         println!(
             "  Tracked working set: {:.1} MB — bounded by strip height, not canvas area.",
@@ -766,7 +764,8 @@ fn main() {
             largest.0,
             largest.1,
             largest_mp,
-            streaming_budget_for(largest.0, TILE_SIZE) as f64 / (1024.0 * 1024.0),
+            streaming_budget_for(STREAMING_BUDGET_FLOOR, largest.0, TILE_SIZE, 3) as f64
+                / (1024.0 * 1024.0),
         );
         println!(
             "  Tracked working set: {:.1} MB — same strip-bounded model as streaming.",

--- a/tests/output_equivalence.rs
+++ b/tests/output_equivalence.rs
@@ -167,6 +167,44 @@ fn corrupt_tile(files: &Path, level: u32, col: u32, row: u32) {
     image::ImageEncoder::write_image(enc, &inverted, w, h, image::ColorType::Rgb8.into()).unwrap();
 }
 
+/// The spot-check builds each libviprs engine's OWN candidate pyramid through
+/// [`write_libviprs_pyramid`] under the report's flat 1 MB budget floor. The
+/// 1024² fixture's worst-case tile-aligned strip (`1024 × 2·256 × 3 = 1.5 MB`)
+/// exceeds that floor, so before #38's sizing was applied inside
+/// `write_libviprs_pyramid` the streaming / mapreduce candidate build returned
+/// `BudgetExceeded` and every spot-check at >= 1024 px silently degraded to "no
+/// score". This guards that both budget-driven engines now build a real
+/// candidate under the raw floor. Needs no libvips (only the candidate side).
+#[test]
+fn budget_driven_candidate_pyramids_build_under_the_report_floor() {
+    let raster = fixture_raster();
+    let (w, h) = (raster.width(), raster.height());
+    assert!(
+        w >= 1024,
+        "fixture must be large enough to exceed the 1 MB floor"
+    );
+    let plan = PyramidPlanner::new(w, h, TILE, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+    let root = std::env::temp_dir().join(format!("libviprs_equiv_budget_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+
+    for (engine, tag) in [
+        (EngineKind::Streaming, "stream"),
+        (EngineKind::MapReduce, "mr"),
+    ] {
+        let base = write_libviprs_pyramid(&raster, &plan, engine, 0, 1_000_000, &root.join(tag))
+            .unwrap_or_else(|e| panic!("{tag} candidate must build under the 1 MB floor, got {e}"));
+        let level_dirs = std::fs::read_dir(&base)
+            .expect("candidate pyramid root exists")
+            .filter_map(Result::ok)
+            .filter(|e| e.path().is_dir())
+            .count();
+        assert!(level_dirs > 0, "{tag} candidate must emit pyramid levels");
+    }
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 #[test]
 fn fixture_tiles_are_output_equivalent_by_psnr() {
     if !vips_available() {

--- a/tests/streaming_budget.rs
+++ b/tests/streaming_budget.rs
@@ -1,0 +1,107 @@
+//! Report-path memory-budget sizing for the streaming / mapreduce engines (#38).
+//!
+//! The everyday `report` run drives every streaming and mapreduce cell through
+//! [`bench_streaming`](libviprs_bench::bench_streaming) /
+//! [`bench_mapreduce`](libviprs_bench::bench_mapreduce) with a single flat
+//! ~1 MB budget ([`BENCH_STREAMING_BUDGET`](libviprs_bench::BENCH_STREAMING_BUDGET))
+//! under the strict `BudgetPolicy::Error`. That budget is smaller than the
+//! worst-case tile-aligned strip (`width × 2·tile_size × bpp`) the engines must
+//! admit once the canvas reaches 1024 px, so at the large report sizes
+//! (1024 / 2048 / 4096) both engines rejected the run up front with
+//! `BudgetExceeded` — and the harness `.unwrap()` turned that into a panic,
+//! silently dropping the streaming and mapreduce rows from the report while the
+//! monolithic and libvips rows survived.
+//!
+//! These guards pin that a large cell now completes under the report's default
+//! budget and yields a valid pyramid, and that the budget the cell actually ran
+//! with was sized large enough to admit that worst-case strip. They need no
+//! libvips, so they run unconditionally.
+
+use libviprs::{Layout, PyramidPlanner};
+use libviprs_bench::{
+    BENCH_STREAMING_BUDGET, BENCH_TILE_SIZE, RunMetrics, bench_mapreduce, bench_streaming,
+    gradient_raster,
+};
+
+/// A large-enough canvas that the report's flat 1 MB budget cannot fit the
+/// worst-case tile-aligned strip: `1024 × 2·256 × 3 = 1_572_864` B > 1 MB.
+/// Kept at exactly 1024² (a handful of tiles) so the run stays fast.
+const W: u32 = 1024;
+const H: u32 = 1024;
+/// [`gradient_raster`] is RGB8, so the engine's pre-flight admits a worst-case
+/// strip of `width × 2·tile_size × bpp` at 3 bytes per pixel.
+const BPP: u64 = 3;
+
+/// The minimum aligned strip the streaming/mapreduce pre-flight must admit at
+/// [`W`] — mirror of the engine's own `canvas_width × 2·tile_size × bpp`.
+fn worst_case_strip_bytes() -> u64 {
+    W as u64 * 2 * BENCH_TILE_SIZE as u64 * BPP
+}
+
+/// Shared assertions: the cell produced a valid, non-empty pyramid and ran
+/// under a budget sized to admit the worst-case tile-aligned strip.
+fn assert_valid_large_pyramid(m: &RunMetrics, engine: &str) {
+    assert_eq!(m.engine, engine, "row must report its own engine series");
+    assert!(
+        m.tiles_produced > 0,
+        "{engine} must emit a non-empty pyramid at {W}x{H} under the report's \
+         default budget, got {} tiles",
+        m.tiles_produced
+    );
+    assert!(
+        !m.per_level_tiles.is_empty(),
+        "per-level grid must be populated"
+    );
+    assert_eq!(
+        m.per_level_tiles.iter().sum::<u64>(),
+        m.tiles_produced,
+        "per-level tiles must sum to the total"
+    );
+    assert!(
+        m.strips > 0,
+        "the {engine} path must render at least one strip"
+    );
+    // Regression guard: the budget the cell actually ran with (reported back in
+    // `memory_budget_bytes`) must be large enough to admit the worst-case
+    // tile-aligned strip, otherwise the strict `BudgetPolicy::Error` would have
+    // tripped `BudgetExceeded`.
+    assert!(
+        m.memory_budget_bytes >= worst_case_strip_bytes(),
+        "sized budget {} must admit the worst-case tile-aligned strip {} \
+         (width x 2*tile_size x bpp)",
+        m.memory_budget_bytes,
+        worst_case_strip_bytes()
+    );
+}
+
+/// The report's default 1 MB budget must not make the streaming engine panic
+/// with `BudgetExceeded` at 1024²; it must degrade to a properly-sized budget
+/// and produce a valid pyramid. RED against the pre-fix code, where
+/// `bench_streaming` `.unwrap()`s the over-budget engine run and panics.
+#[test]
+fn report_default_budget_admits_large_streaming_pyramid() {
+    let src = gradient_raster(W, H);
+    let plan = PyramidPlanner::new(W, H, BENCH_TILE_SIZE, 0, Layout::DeepZoom)
+        .expect("plan the pyramid")
+        .plan();
+
+    // Exactly the budget/policy the report drives every streaming cell with.
+    let m = bench_streaming(&src, &plan, 0, BENCH_STREAMING_BUDGET, "budget38_stream");
+
+    assert_valid_large_pyramid(&m, "streaming");
+}
+
+/// The mapreduce counterpart: the same flat budget must not panic the
+/// mapreduce engine at 1024², which likewise rejected the run up front before
+/// the budget was sized per image.
+#[test]
+fn report_default_budget_admits_large_mapreduce_pyramid() {
+    let src = gradient_raster(W, H);
+    let plan = PyramidPlanner::new(W, H, BENCH_TILE_SIZE, 0, Layout::DeepZoom)
+        .expect("plan the pyramid")
+        .plan();
+
+    let m = bench_mapreduce(&src, &plan, 0, BENCH_STREAMING_BUDGET, "budget38_mr");
+
+    assert_valid_large_pyramid(&m, "mapreduce");
+}


### PR DESCRIPTION
Resolves **#38**. The report harness drove streaming/mapreduce with a flat ~1 MB budget under `BudgetPolicy::Error`, so from 1024px up the worst-case tile-aligned strip exceeded the budget → `BudgetExceeded` panic → streaming/mapreduce rows silently vanished at large sizes (only monolithic/libvips survived). Fix: a shared `streaming_budget_for(floor, canvas_width, tile_size, bpp)` helper sizes the budget to admit the worst-case strip (saturating math), wired into bench_streaming/bench_mapreduce/bench_streaming_pdf + write_libviprs_pyramid + flamegraph.rs; scalability's duplicate copy deleted (single source). report + snapshot now report the effective per-run budget.

TDD: commit 1 RED tests (reproduce the panic at 1024²); commit 2 fix. 4-expert review applied. Rebased onto charts/#22/#23/#24 (removed the crop const + scalability's duplicate helper). Filed follow-ups #46 (.run().unwrap() → Result) and #47 (core-exposed budget primitive) — **both to be resolved in the convergence sweep**. Local gate green.

Closes #38