### PR TITLE
Dockerfile reproducibility: pin apt + validate the libvips pin against upstream (#35, #36)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,14 @@ sha2 = "0.11"
 name = "engine_comparison"
 harness = false
 
+# On-demand upstream-pin validator (libviprs-bench #35/#36). Reads a GitHub
+# releases JSON payload on stdin and classifies the recorded libvips pin via
+# `pin_check::classify_libvips_pin` — the single classifier the tests exercise.
+# `tools/check-libvips-pin.sh` curl-fetches the feed and pipes it here.
+[[bin]]
+name = "check-libvips-pin"
+path = "src/check_libvips_pin.rs"
+
 [[bin]]
 name = "flamegraph"
 path = "src/flamegraph.rs"

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,13 @@
 #                     the live bookworm mirror (#35, closing the #33 scope gap)
 # The Rust and Debian base images are digest-pinned (`@sha256:`) on the FROM
 # lines below, so no layer floats on a mutable tag either (#35).
+#
+# Availability note (#35): pinning apt to snapshot.debian.org routes every
+# package fetch through a single archive host that is historically slow and can
+# be briefly rate-limited or degraded. That is the deliberate cost of a frozen
+# mirror; apt is set to retry and the libvips/PDFium tarball fetches use
+# `curl --retry`, so a transient snapshot blip should be re-run rather than
+# treated as a real failure.
 # ---------------------------------------------------------------------------
 ARG PDFIUM_RELEASE=pdfium-7881
 # Upstream libvips release compiled from source (issue #33). Kept in lockstep
@@ -52,6 +59,10 @@ FROM debian:bookworm-20250929-slim@sha256:7e490910eea2861b9664577a96b54ce68ea3e0
 # stage's `curl` resolves from a frozen mirror (#35). See the builder stage for
 # the full rationale; the deb822 source is rewritten wholesale (keeping the
 # stock archive keyring) so the pin is independent of the base image's layout.
+# NOTE: this deb822 snapshot block is duplicated verbatim in the builder stage
+# below (the canonical copy). The builder is `rust:*-bookworm` and cannot share
+# this Debian base image, so the two are kept intentionally in sync — edit both
+# together when either changes.
 ARG DEBIAN_SNAPSHOT
 RUN printf 'Types: deb\nURIs: http://snapshot.debian.org/archive/debian/%s\nSuites: bookworm bookworm-updates\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\nTypes: deb\nURIs: http://snapshot.debian.org/archive/debian-security/%s\nSuites: bookworm-security\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n' \
         "${DEBIAN_SNAPSHOT}" "${DEBIAN_SNAPSHOT}" > /etc/apt/sources.list.d/debian.sources && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,16 @@
 # Pinned inputs. A benchmark is only reproducible if every layer is fixed:
 # a floating base image, an unpinned libvips, or a `latest` PDFium would
 # silently change the numbers between runs (issue #153). Bump these
-# deliberately, never implicitly. (One documented exception — the apt codec
-# `-dev` packages libvips links against are not snapshot-pinned; that scope is
-# spelled out in the builder stage and tracked in #35.)
+# deliberately, never implicitly.
 #   PDFIUM_RELEASE  — libviprs-dep release tag (checksum-verified builder)
 #   LIBVIPS_VERSION — upstream libvips source release, built from tarball
 #   LIBVIPS_SHA256  — SHA-256 of that tarball, verified before it is built
-# The Rust and Debian base images are pinned by tag on the FROM lines below.
+#   DEBIAN_SNAPSHOT — snapshot.debian.org timestamp the apt toolchain resolves
+#                     against, so the codec `-dev` libraries (libpng et al. —
+#                     the DeepZoom PNG hot path) are fixed too, not floated on
+#                     the live bookworm mirror (#35, closing the #33 scope gap)
+# The Rust and Debian base images are digest-pinned (`@sha256:`) on the FROM
+# lines below, so no layer floats on a mutable tag either (#35).
 # ---------------------------------------------------------------------------
 ARG PDFIUM_RELEASE=pdfium-7881
 # Upstream libvips release compiled from source (issue #33). Kept in lockstep
@@ -34,9 +37,26 @@ ARG PDFIUM_RELEASE=pdfium-7881
 # `vips-<version>.tar.xz.sha256sum` companion file.
 ARG LIBVIPS_VERSION=8.18.4
 ARG LIBVIPS_SHA256=2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037
+# Dated snapshot.debian.org mirror the apt toolchain resolves against (#35).
+# Matches the Debian base image's own build date (bookworm-20250929) so the
+# whole image is one frozen point in time. snapshot.debian.org resolves a
+# timestamp to the nearest snapshot at or before it, so a dated value always
+# lands on a real snapshot.
+ARG DEBIAN_SNAPSHOT=20250929T000000Z
 
-# Stage 1: Download PDFium for the target architecture
-FROM debian:bookworm-20250929-slim AS pdfium
+# Stage 1: Download PDFium for the target architecture. Base image digest-pinned
+# (not just tag-pinned) so the exact layer cannot shift under a rebuild (#35).
+FROM debian:bookworm-20250929-slim@sha256:7e490910eea2861b9664577a96b54ce68ea3e02ce7f51d89cb0103a6f9c386e0 AS pdfium
+
+# Pin apt to the dated Debian snapshot before installing anything, so even this
+# stage's `curl` resolves from a frozen mirror (#35). See the builder stage for
+# the full rationale; the deb822 source is rewritten wholesale (keeping the
+# stock archive keyring) so the pin is independent of the base image's layout.
+ARG DEBIAN_SNAPSHOT
+RUN printf 'Types: deb\nURIs: http://snapshot.debian.org/archive/debian/%s\nSuites: bookworm bookworm-updates\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\nTypes: deb\nURIs: http://snapshot.debian.org/archive/debian-security/%s\nSuites: bookworm-security\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n' \
+        "${DEBIAN_SNAPSHOT}" "${DEBIAN_SNAPSHOT}" > /etc/apt/sources.list.d/debian.sources && \
+    rm -f /etc/apt/sources.list && \
+    printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "3";\n' > /etc/apt/apt.conf.d/10snapshot
 
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
@@ -63,8 +83,9 @@ RUN case "${TARGETARCH}" in \
 
 # Stage 2: Build and run benchmarks
 # Pinned Rust (was `rust:latest`) so the compiler and its bundled toolchain
-# do not drift between benchmark runs (issue #153).
-FROM rust:1.89-bookworm AS builder
+# do not drift between benchmark runs (issue #153); digest-pinned (not just
+# tag-pinned) so the exact base layer cannot shift under a rebuild (#35).
+FROM rust:1.89-bookworm@sha256:948f9b08a66e7fe01b03a98ef1c7568292e07ec2e4fe90d88c07bb14563c84ff AS builder
 
 ARG LIBVIPS_VERSION
 ARG LIBVIPS_SHA256
@@ -80,15 +101,24 @@ ARG LIBVIPS_SHA256
 # benchmark's hot path (DeepZoom writes PNG tiles), but jpeg/tiff/webp are
 # included so the oracle is a realistic, full-featured libvips build.
 #
-# Reproducibility scope (issue #33, tracked in #35): libvips itself is pinned
-# by version + SHA-256 and the base images by tag, but these apt `-dev`
-# packages are NOT snapshot-pinned — `apt-get install` resolves them against
-# bookworm's live mirror, so an intra-bookworm point release (e.g. a libpng
-# security update) can shift under a rebuild. Accepted deliberately here:
-# point releases hold ABI and rarely move the encode hot path materially, and
-# the meson force-enable below fails the build if a codec disappears entirely.
-# Fully closing this (a dated snapshot.debian.org source or digest-pinned
-# base) is deferred to #35.
+# Reproducibility scope (#35, closing the #33 gap): the apt toolchain is pinned
+# to the dated snapshot.debian.org mirror set up just below, so these `-dev`
+# packages resolve to fixed versions instead of bookworm's live mirror. Without
+# it an intra-bookworm point release (e.g. a libpng security update) could shift
+# the encode hot path under a rebuild — libpng directly shapes the measured
+# DeepZoom PNG-tile numbers. The meson force-enable further hard-fails the build
+# if a codec ever disappears from the snapshot entirely.
+#
+# The deb822 source is rewritten wholesale to the snapshot (keeping the stock
+# `debian-archive-keyring` so releases stay GPG-verified), and
+# `Check-Valid-Until false` is required because a dated snapshot's Release file
+# carries an expired `Valid-Until`.
+ARG DEBIAN_SNAPSHOT
+RUN printf 'Types: deb\nURIs: http://snapshot.debian.org/archive/debian/%s\nSuites: bookworm bookworm-updates\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\nTypes: deb\nURIs: http://snapshot.debian.org/archive/debian-security/%s\nSuites: bookworm-security\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n' \
+        "${DEBIAN_SNAPSHOT}" "${DEBIAN_SNAPSHOT}" > /etc/apt/sources.list.d/debian.sources && \
+    rm -f /etc/apt/sources.list && \
+    printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "3";\n' > /etc/apt/apt.conf.d/10snapshot
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/src/check_libvips_pin.rs
+++ b/src/check_libvips_pin.rs
@@ -1,0 +1,68 @@
+//! `check-libvips-pin` — classify the recorded libvips pin against an upstream
+//! GitHub releases payload read from stdin, exiting with a status code the
+//! `tools/check-libvips-pin.sh` wrapper (or a cron) can act on.
+//!
+//! This is the single on-demand classification path: it calls
+//! [`classify_libvips_pin`] over the same [`PINNED_LIBVIPS_VERSION`] /
+//! [`PINNED_LIBVIPS_SHA256`] the
+//! benchmark records, so the operator check and the in-process tests can never
+//! classify the same feed differently. The shell wrapper only fetches the feed
+//! (`curl`) and pipes it here — there is no parallel shell-side classifier.
+//!
+//! Exit codes: `0` up-to-date · `1` an actionable drift (a newer release or a
+//! digest mismatch) · `2` could not check (pin/asset absent from the feed
+//! window, no stable release, or a malformed/unreadable payload).
+
+use std::io::Read;
+use std::process::ExitCode;
+
+use libviprs_bench::pin_check::{
+    LibvipsPinStatus, PINNED_LIBVIPS_SHA256, PINNED_LIBVIPS_VERSION, classify_libvips_pin,
+};
+
+fn main() -> ExitCode {
+    let mut releases_json = String::new();
+    if let Err(e) = std::io::stdin().read_to_string(&mut releases_json) {
+        eprintln!("check-libvips-pin: could not read the releases payload from stdin: {e}");
+        return ExitCode::from(2);
+    }
+
+    match classify_libvips_pin(
+        &releases_json,
+        PINNED_LIBVIPS_VERSION,
+        PINNED_LIBVIPS_SHA256,
+    ) {
+        Ok(LibvipsPinStatus::UpToDate) => {
+            println!(
+                "OK: pinned libvips {PINNED_LIBVIPS_VERSION} is the latest stable upstream and its \
+                 tarball SHA-256 matches."
+            );
+            ExitCode::SUCCESS
+        }
+        Ok(LibvipsPinStatus::NewerReleaseAvailable { latest }) => {
+            println!(
+                "NEWER RELEASE: upstream latest stable is {latest} (pinned \
+                 {PINNED_LIBVIPS_VERSION}) — bump the pin."
+            );
+            ExitCode::from(1)
+        }
+        Ok(LibvipsPinStatus::Sha256Mismatch { pinned, upstream }) => {
+            eprintln!(
+                "MISMATCH: upstream vips-{PINNED_LIBVIPS_VERSION}.tar.xz now advertises {upstream}, \
+                 but the pin records {pinned}. Upstream re-cut the tarball, or the pin is wrong."
+            );
+            ExitCode::from(1)
+        }
+        Ok(LibvipsPinStatus::PinnedReleaseNotFound) => {
+            eprintln!(
+                "COULD NOT VERIFY: vips-{PINNED_LIBVIPS_VERSION}.tar.xz (or its digest) was not \
+                 found in the upstream feed window, so the SHA-256 could not be checked."
+            );
+            ExitCode::from(2)
+        }
+        Err(e) => {
+            eprintln!("check-libvips-pin: {e}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ use libviprs::{
 use serde::{Deserialize, Serialize};
 
 pub mod harness;
+pub mod pin_check;
 pub mod provenance;
 pub mod version_id;
 pub mod version_matrix;

--- a/src/pin_check.rs
+++ b/src/pin_check.rs
@@ -1,0 +1,220 @@
+//! On-demand validation of the pinned libvips against the upstream feed.
+//!
+//! [`provenance`](crate::provenance) fingerprints the environment *per run*.
+//! This module serves a different, maintenance-time need with a different
+//! collaborator: before a pin bump, confirm the recorded pin
+//! ([`PINNED_LIBVIPS_VERSION`] / [`PINNED_LIBVIPS_SHA256`]) is still the latest
+//! stable upstream libvips and that its tarball digest still matches the bytes
+//! GitHub serves. It talks to the remote GitHub releases API rather than the
+//! local host, so it is deliberately kept out of the per-snapshot
+//! [`provenance`](crate::provenance) capture path.
+//!
+//! The classification itself is network-free: [`classify_libvips_pin`] takes a
+//! payload the caller already fetched, so the *same* logic runs over a captured
+//! fixture in tests and a live `curl` in the `check-libvips-pin` binary that
+//! `tools/check-libvips-pin.sh` wraps. There is no second implementation to
+//! drift from it. It is advisory, never a PR gate: this repo gates locally and
+//! skips GitHub CI on PR commits (libviprs-bench #36).
+
+use serde::Deserialize;
+
+use crate::provenance::strip_libvips_prefixes;
+
+// The pin constants live in `provenance` (stamped into every snapshot); re-export
+// them here so a consumer of the validator can reach the pin it validates from
+// one place.
+pub use crate::provenance::{PINNED_LIBVIPS_SHA256, PINNED_LIBVIPS_VERSION};
+
+/// Parse a libvips version/tag string down to `(major, minor, patch)`.
+///
+/// Accepts the GitHub release tag (`"v8.18.4"`), the `vips --version` line
+/// (`"vips-8.18.4"`), and the bare pin (`"8.18.4"`) — prefix handling is shared
+/// with [`crate::provenance::parse_libvips_major_minor`] via
+/// `strip_libvips_prefixes`. Unlike that sibling, the patch component is
+/// *required*: upstream releases always carry one, and [`classify_libvips_pin`]
+/// compares whole `(major, minor, patch)` tuples to decide whether a newer
+/// release exists. A pre-release tag (`"v8.18.3-rc1"`, whose patch is
+/// non-numeric) yields `None`, so a release candidate can never rank as — or
+/// newer than — a finished release.
+pub fn parse_libvips_version(tag: &str) -> Option<(u32, u32, u32)> {
+    let digits = strip_libvips_prefixes(tag);
+    let mut parts = digits.split('.');
+    let major = parts.next()?.parse::<u32>().ok()?;
+    let minor = parts.next()?.parse::<u32>().ok()?;
+    let patch = parts.next()?.parse::<u32>().ok()?;
+    Some((major, minor, patch))
+}
+
+/// Outcome of validating the pinned libvips ([`PINNED_LIBVIPS_VERSION`] /
+/// [`PINNED_LIBVIPS_SHA256`]) against the upstream GitHub releases feed.
+///
+/// Produced by [`classify_libvips_pin`] from a captured or live
+/// `GET /repos/libvips/libvips/releases` payload. The on-demand validator (the
+/// `check-libvips-pin` binary, `tools/check-libvips-pin.sh`, and the
+/// `#[ignore]`d live test) renders it; it is deliberately advisory, never a PR
+/// gate — this repo gates locally and skips GitHub CI on PR commits
+/// (libviprs-bench #36).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LibvipsPinStatus {
+    /// The pin is the latest stable upstream release and its tarball SHA-256
+    /// still matches — nothing to do.
+    UpToDate,
+    /// A stable upstream release strictly newer than the pin exists.
+    NewerReleaseAvailable {
+        /// Latest stable upstream version, `"major.minor.patch"` — the bump
+        /// target an operator sees.
+        latest: String,
+    },
+    /// The pinned release's upstream tarball digest no longer matches
+    /// [`PINNED_LIBVIPS_SHA256`] — upstream re-published the asset, or the
+    /// recorded digest is wrong. The integrity signal; reported ahead of a mere
+    /// version bump so a re-cut pinned tarball is never masked by "there is a
+    /// newer version anyway".
+    Sha256Mismatch {
+        /// The recorded pin (the `pinned_sha256` argument).
+        pinned: String,
+        /// The digest the upstream release now advertises for the pinned tarball.
+        upstream: String,
+    },
+    /// The pinned tarball's digest could not be located in the feed, so the
+    /// SHA could not be validated — indeterminate, not a pass. Fires both when
+    /// the pinned release is absent from the feed window (e.g. a pin newer than
+    /// anything upstream) and when the release is present but its
+    /// `vips-<version>.tar.xz` asset (or that asset's `digest`) is missing.
+    /// Mirrors [`crate::provenance::OracleMatch::Indeterminate`]'s "no verdict"
+    /// role.
+    PinnedReleaseNotFound,
+}
+
+/// Why [`classify_libvips_pin`] could not reach a verdict from a payload.
+#[derive(Debug)]
+pub enum LibvipsPinError {
+    /// The payload was not valid JSON in the expected releases-array shape.
+    /// Wraps the underlying [`serde_json::Error`], preserved so
+    /// [`std::error::Error::source`] exposes its structured line/column cause.
+    Parse(serde_json::Error),
+    /// The payload carried no stable (non-draft, non-pre-release) release, so
+    /// there is nothing to compare the pin against.
+    NoStableRelease,
+}
+
+impl std::fmt::Display for LibvipsPinError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Parse(e) => write!(f, "could not parse the releases payload: {e}"),
+            Self::NoStableRelease => write!(f, "the releases payload carried no stable release"),
+        }
+    }
+}
+
+impl std::error::Error for LibvipsPinError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Parse(e) => Some(e),
+            Self::NoStableRelease => None,
+        }
+    }
+}
+
+/// One GitHub release, trimmed to the fields the validator reads. Unknown
+/// fields are ignored, so the real API payload deserializes unchanged.
+#[derive(Deserialize)]
+struct GhRelease {
+    tag_name: String,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    prerelease: bool,
+    #[serde(default)]
+    assets: Vec<GhAsset>,
+}
+
+/// One release asset: its file name and (when the API provides it) the
+/// `"sha256:<hex>"` digest GitHub advertises for it.
+#[derive(Deserialize)]
+struct GhAsset {
+    name: String,
+    #[serde(default)]
+    digest: Option<String>,
+}
+
+/// Strip the `sha256:` scheme prefix GitHub asset digests carry.
+fn strip_sha256_prefix(digest: &str) -> &str {
+    digest.strip_prefix("sha256:").unwrap_or(digest)
+}
+
+/// Validate the recorded libvips pin (`pinned_version` / `pinned_sha256`,
+/// normally [`PINNED_LIBVIPS_VERSION`] / [`PINNED_LIBVIPS_SHA256`]) against a
+/// GitHub releases API payload (`GET /repos/libvips/libvips/releases`, a JSON
+/// array).
+///
+/// Host-independent and network-free: the caller supplies the payload — a
+/// captured sample in tests, a live `curl` fetch in the on-demand validator —
+/// so the same classification logic runs in both. Integrity beats freshness: a
+/// tarball digest that no longer matches upstream
+/// ([`LibvipsPinStatus::Sha256Mismatch`]) is reported ahead of a mere newer
+/// release, so a re-published pinned asset is never masked by a version bump.
+///
+/// `pinned_version` may be given in any form [`parse_libvips_version`] accepts
+/// (`"v8.18.4"` / `"vips-8.18.4"` / `"8.18.4"`); the tarball asset name is
+/// rebuilt from the *parsed* `major.minor.patch`, so every accepted form
+/// resolves to the same `vips-<x.y.z>.tar.xz` and the version compare and the
+/// digest lookup can never disagree on the input's shape.
+pub fn classify_libvips_pin(
+    releases_json: &str,
+    pinned_version: &str,
+    pinned_sha256: &str,
+) -> Result<LibvipsPinStatus, LibvipsPinError> {
+    let releases: Vec<GhRelease> =
+        serde_json::from_str(releases_json).map_err(LibvipsPinError::Parse)?;
+
+    // Latest *stable* release: drafts and pre-releases (e.g. `v8.18.3-rc1`) are
+    // never a bump target.
+    let latest_stable = releases
+        .iter()
+        .filter(|r| !r.draft && !r.prerelease)
+        .filter_map(|r| parse_libvips_version(&r.tag_name))
+        .max()
+        .ok_or(LibvipsPinError::NoStableRelease)?;
+
+    // Locate the pinned *stable* release's tarball digest, if the feed carries
+    // it. The asset name is rebuilt from the parsed tuple so a `v`-/`vips-`
+    // prefixed pin resolves to the same `vips-<x.y.z>.tar.xz` the version
+    // compare keys off, and only finished stable releases (never a draft or
+    // pre-release parsing to the same version) may supply the digest.
+    let pinned_ver = parse_libvips_version(pinned_version);
+    let upstream_digest: Option<&str> = pinned_ver.and_then(|pv| {
+        let (major, minor, patch) = pv;
+        let tarball = format!("vips-{major}.{minor}.{patch}.tar.xz");
+        releases
+            .iter()
+            .filter(|r| !r.draft && !r.prerelease && parse_libvips_version(&r.tag_name) == Some(pv))
+            .flat_map(|r| r.assets.iter())
+            .find(|a| a.name == tarball)
+            .and_then(|a| a.digest.as_deref())
+            .map(strip_sha256_prefix)
+    });
+
+    // Integrity first: a re-cut pinned tarball outranks a newer release.
+    if let Some(upstream) = upstream_digest.filter(|u| !u.eq_ignore_ascii_case(pinned_sha256)) {
+        return Ok(LibvipsPinStatus::Sha256Mismatch {
+            pinned: pinned_sha256.to_string(),
+            upstream: upstream.to_string(),
+        });
+    }
+
+    // Then freshness: a strictly newer stable release is a bump target.
+    if pinned_ver.is_some_and(|pv| latest_stable > pv) {
+        let (major, minor, patch) = latest_stable;
+        return Ok(LibvipsPinStatus::NewerReleaseAvailable {
+            latest: format!("{major}.{minor}.{patch}"),
+        });
+    }
+
+    // The pin is current, but its digest could not be located to confirm it.
+    if upstream_digest.is_none() {
+        return Ok(LibvipsPinStatus::PinnedReleaseNotFound);
+    }
+
+    Ok(LibvipsPinStatus::UpToDate)
+}

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -38,8 +38,10 @@ pub const PINNED_LIBVIPS_VERSION: &str = "8.18.4";
 /// exactly this value. Cross-checked against the upstream
 /// `vips-{PINNED_LIBVIPS_VERSION}.tar.xz.sha256sum` companion file — refresh
 /// it in the same edit whenever [`PINNED_LIBVIPS_VERSION`] is bumped.
-/// Validating the digest against the *real* upstream tarball on a schedule is
-/// tracked as a follow-up (libviprs-bench #36).
+/// [`classify_libvips_pin`] validates this digest (and the version) against the
+/// live upstream GitHub releases feed — run it on demand via
+/// `tools/check-libvips-pin.sh` or the `#[ignore]`d live test (libviprs-bench
+/// #36).
 pub const PINNED_LIBVIPS_SHA256: &str =
     "2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037";
 
@@ -236,6 +238,178 @@ pub fn parse_libvips_major_minor(version: &str) -> Option<(u32, u32)> {
     let major = parts.next()?.parse::<u32>().ok()?;
     let minor = parts.next()?.parse::<u32>().ok()?;
     Some((major, minor))
+}
+
+/// Parse a libvips version/tag string down to `(major, minor, patch)`.
+///
+/// Accepts the GitHub release tag (`"v8.18.4"`), the `vips --version` line
+/// (`"vips-8.18.4"`), and the bare pin (`"8.18.4"`). Unlike
+/// [`parse_libvips_major_minor`], the patch component is *required*: upstream
+/// releases always carry one, and [`classify_libvips_pin`] compares whole
+/// `(major, minor, patch)` tuples to decide whether a newer release exists. A
+/// pre-release tag (`"v8.18.3-rc1"`, whose patch is non-numeric) yields `None`,
+/// so a release candidate can never rank as — or newer than — a finished
+/// release.
+pub fn parse_libvips_version(tag: &str) -> Option<(u32, u32, u32)> {
+    let trimmed = tag.trim();
+    let no_vips = trimmed.strip_prefix("vips-").unwrap_or(trimmed);
+    let digits = no_vips.strip_prefix('v').unwrap_or(no_vips);
+    let mut parts = digits.split('.');
+    let major = parts.next()?.parse::<u32>().ok()?;
+    let minor = parts.next()?.parse::<u32>().ok()?;
+    let patch = parts.next()?.parse::<u32>().ok()?;
+    Some((major, minor, patch))
+}
+
+/// Outcome of validating the pinned libvips ([`PINNED_LIBVIPS_VERSION`] /
+/// [`PINNED_LIBVIPS_SHA256`]) against the upstream GitHub releases feed.
+///
+/// Produced by [`classify_libvips_pin`] from a captured or live
+/// `GET /repos/libvips/libvips/releases` payload. The on-demand validator
+/// (`tools/check-libvips-pin.sh` and the `#[ignore]`d live test) renders it; it
+/// is deliberately advisory, never a PR gate — this repo gates locally and
+/// skips GitHub CI on PR commits (libviprs-bench #36).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LibvipsPinStatus {
+    /// The pin is the latest stable upstream release and its tarball SHA-256
+    /// still matches — nothing to do.
+    UpToDate,
+    /// A stable upstream release strictly newer than the pin exists.
+    NewerReleaseAvailable {
+        /// Latest stable upstream version, `"major.minor.patch"` — the bump
+        /// target an operator sees.
+        latest: String,
+    },
+    /// The pinned release's upstream tarball digest no longer matches
+    /// [`PINNED_LIBVIPS_SHA256`] — upstream re-published the asset, or the
+    /// recorded digest is wrong. The integrity signal; reported ahead of a mere
+    /// version bump so a re-cut pinned tarball is never masked by "there is a
+    /// newer version anyway".
+    Sha256Mismatch {
+        /// The recorded pin (the `pinned_sha256` argument).
+        pinned: String,
+        /// The digest the upstream release now advertises for the pinned tarball.
+        upstream: String,
+    },
+    /// The pinned release (or its `vips-<version>.tar.xz` asset with a digest)
+    /// was not found in the feed, so the SHA could not be validated —
+    /// indeterminate, not a pass. Mirrors [`OracleMatch::Indeterminate`]'s
+    /// "no verdict" role.
+    PinnedReleaseNotFound,
+}
+
+/// Why [`classify_libvips_pin`] could not reach a verdict from a payload.
+#[derive(Debug)]
+pub enum LibvipsPinError {
+    /// The payload was not valid JSON in the expected releases-array shape.
+    /// Carries the underlying `serde_json` message.
+    Parse(String),
+    /// The payload carried no stable (non-draft, non-pre-release) release, so
+    /// there is nothing to compare the pin against.
+    NoStableRelease,
+}
+
+impl std::fmt::Display for LibvipsPinError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Parse(e) => write!(f, "could not parse the releases payload: {e}"),
+            Self::NoStableRelease => write!(f, "the releases payload carried no stable release"),
+        }
+    }
+}
+
+impl std::error::Error for LibvipsPinError {}
+
+/// One GitHub release, trimmed to the fields the validator reads. Unknown
+/// fields are ignored, so the real API payload deserializes unchanged.
+#[derive(Deserialize)]
+struct GhRelease {
+    tag_name: String,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    prerelease: bool,
+    #[serde(default)]
+    assets: Vec<GhAsset>,
+}
+
+/// One release asset: its file name and (when the API provides it) the
+/// `"sha256:<hex>"` digest GitHub advertises for it.
+#[derive(Deserialize)]
+struct GhAsset {
+    name: String,
+    #[serde(default)]
+    digest: Option<String>,
+}
+
+/// Strip the `sha256:` scheme prefix GitHub asset digests carry.
+fn strip_sha256_prefix(digest: &str) -> &str {
+    digest.strip_prefix("sha256:").unwrap_or(digest)
+}
+
+/// Validate the recorded libvips pin (`pinned_version` / `pinned_sha256`,
+/// normally [`PINNED_LIBVIPS_VERSION`] / [`PINNED_LIBVIPS_SHA256`]) against a
+/// GitHub releases API payload (`GET /repos/libvips/libvips/releases`, a JSON
+/// array).
+///
+/// Host-independent and network-free: the caller supplies the payload — a
+/// captured sample in tests, a live `curl` fetch in the on-demand validator —
+/// so the same classification logic runs in both. Integrity beats freshness: a
+/// tarball digest that no longer matches upstream
+/// ([`LibvipsPinStatus::Sha256Mismatch`]) is reported ahead of a mere newer
+/// release, so a re-published pinned asset is never masked by a version bump.
+pub fn classify_libvips_pin(
+    releases_json: &str,
+    pinned_version: &str,
+    pinned_sha256: &str,
+) -> Result<LibvipsPinStatus, LibvipsPinError> {
+    let releases: Vec<GhRelease> =
+        serde_json::from_str(releases_json).map_err(|e| LibvipsPinError::Parse(e.to_string()))?;
+
+    // Latest *stable* release: drafts and pre-releases (e.g. `v8.18.3-rc1`) are
+    // never a bump target.
+    let latest_stable = releases
+        .iter()
+        .filter(|r| !r.draft && !r.prerelease)
+        .filter_map(|r| parse_libvips_version(&r.tag_name))
+        .max()
+        .ok_or(LibvipsPinError::NoStableRelease)?;
+
+    // Locate the pinned release's tarball digest, if the feed carries it.
+    let pinned_ver = parse_libvips_version(pinned_version);
+    let tarball = format!("vips-{pinned_version}.tar.xz");
+    let upstream_digest: Option<&str> = pinned_ver.and_then(|pv| {
+        releases
+            .iter()
+            .filter(|r| parse_libvips_version(&r.tag_name) == Some(pv))
+            .flat_map(|r| r.assets.iter())
+            .find(|a| a.name == tarball)
+            .and_then(|a| a.digest.as_deref())
+            .map(strip_sha256_prefix)
+    });
+
+    // Integrity first: a re-cut pinned tarball outranks a newer release.
+    if let Some(upstream) = upstream_digest.filter(|u| !u.eq_ignore_ascii_case(pinned_sha256)) {
+        return Ok(LibvipsPinStatus::Sha256Mismatch {
+            pinned: pinned_sha256.to_string(),
+            upstream: upstream.to_string(),
+        });
+    }
+
+    // Then freshness: a strictly newer stable release is a bump target.
+    if pinned_ver.is_some_and(|pv| latest_stable > pv) {
+        let (major, minor, patch) = latest_stable;
+        return Ok(LibvipsPinStatus::NewerReleaseAvailable {
+            latest: format!("{major}.{minor}.{patch}"),
+        });
+    }
+
+    // The pin is current, but its digest could not be located to confirm it.
+    if upstream_digest.is_none() {
+        return Ok(LibvipsPinStatus::PinnedReleaseNotFound);
+    }
+
+    Ok(LibvipsPinStatus::UpToDate)
 }
 
 /// Query the libvips version. Prefers the linked library's own

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -38,10 +38,10 @@ pub const PINNED_LIBVIPS_VERSION: &str = "8.18.4";
 /// exactly this value. Cross-checked against the upstream
 /// `vips-{PINNED_LIBVIPS_VERSION}.tar.xz.sha256sum` companion file — refresh
 /// it in the same edit whenever [`PINNED_LIBVIPS_VERSION`] is bumped.
-/// [`classify_libvips_pin`] validates this digest (and the version) against the
-/// live upstream GitHub releases feed — run it on demand via
-/// `tools/check-libvips-pin.sh` or the `#[ignore]`d live test (libviprs-bench
-/// #36).
+/// [`crate::pin_check::classify_libvips_pin`] validates this digest (and the
+/// version) against the live upstream GitHub releases feed — run it on demand
+/// via `tools/check-libvips-pin.sh` or the `#[ignore]`d live test
+/// (libviprs-bench #36).
 pub const PINNED_LIBVIPS_SHA256: &str =
     "2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037";
 
@@ -221,10 +221,27 @@ impl Provenance {
     }
 }
 
+/// Strip the `vips-` and/or a leading `v` prefix a libvips version string may
+/// carry, normalizing the GitHub release tag (`"v8.18.4"`), the `vips
+/// --version` line (`"vips-8.18.4"`), and the bare pin (`"8.18.4"`) to the same
+/// digit string.
+///
+/// Shared by [`parse_libvips_major_minor`] and
+/// [`crate::pin_check::parse_libvips_version`] so the two parsers accept an
+/// identical set of prefixes and differ only in how many components they
+/// require — never in what they will strip.
+pub(crate) fn strip_libvips_prefixes(version: &str) -> &str {
+    let trimmed = version.trim();
+    let no_vips = trimmed.strip_prefix("vips-").unwrap_or(trimmed);
+    no_vips.strip_prefix('v').unwrap_or(no_vips)
+}
+
 /// Parse a libvips version string down to `(major, minor)`.
 ///
-/// Accepts both the raw `vips --version` line (`"vips-8.18.4"`) and the
-/// already-stripped form [`libvips_version`] stores (`"8.18.4"` / `"8.18"`).
+/// Accepts the raw `vips --version` line (`"vips-8.18.4"`), a GitHub release
+/// tag (`"v8.18.4"`), and the already-stripped form [`libvips_version`] stores
+/// (`"8.18.4"` / `"8.18"`) — prefix handling is shared with
+/// [`crate::pin_check::parse_libvips_version`] via `strip_libvips_prefixes`.
 /// Returns `None` for anything without at least a numeric `major.minor`
 /// (e.g. the `"unknown"` sentinel), so a missing capture never compares
 /// equal to a real version. A component carrying a non-digit suffix — a
@@ -232,184 +249,11 @@ impl Provenance {
 /// pinned oracle is always a finished release, so a suffixed string is an
 /// unexpected capture, not a version worth comparing.
 pub fn parse_libvips_major_minor(version: &str) -> Option<(u32, u32)> {
-    let trimmed = version.trim();
-    let digits = trimmed.strip_prefix("vips-").unwrap_or(trimmed);
+    let digits = strip_libvips_prefixes(version);
     let mut parts = digits.split('.');
     let major = parts.next()?.parse::<u32>().ok()?;
     let minor = parts.next()?.parse::<u32>().ok()?;
     Some((major, minor))
-}
-
-/// Parse a libvips version/tag string down to `(major, minor, patch)`.
-///
-/// Accepts the GitHub release tag (`"v8.18.4"`), the `vips --version` line
-/// (`"vips-8.18.4"`), and the bare pin (`"8.18.4"`). Unlike
-/// [`parse_libvips_major_minor`], the patch component is *required*: upstream
-/// releases always carry one, and [`classify_libvips_pin`] compares whole
-/// `(major, minor, patch)` tuples to decide whether a newer release exists. A
-/// pre-release tag (`"v8.18.3-rc1"`, whose patch is non-numeric) yields `None`,
-/// so a release candidate can never rank as — or newer than — a finished
-/// release.
-pub fn parse_libvips_version(tag: &str) -> Option<(u32, u32, u32)> {
-    let trimmed = tag.trim();
-    let no_vips = trimmed.strip_prefix("vips-").unwrap_or(trimmed);
-    let digits = no_vips.strip_prefix('v').unwrap_or(no_vips);
-    let mut parts = digits.split('.');
-    let major = parts.next()?.parse::<u32>().ok()?;
-    let minor = parts.next()?.parse::<u32>().ok()?;
-    let patch = parts.next()?.parse::<u32>().ok()?;
-    Some((major, minor, patch))
-}
-
-/// Outcome of validating the pinned libvips ([`PINNED_LIBVIPS_VERSION`] /
-/// [`PINNED_LIBVIPS_SHA256`]) against the upstream GitHub releases feed.
-///
-/// Produced by [`classify_libvips_pin`] from a captured or live
-/// `GET /repos/libvips/libvips/releases` payload. The on-demand validator
-/// (`tools/check-libvips-pin.sh` and the `#[ignore]`d live test) renders it; it
-/// is deliberately advisory, never a PR gate — this repo gates locally and
-/// skips GitHub CI on PR commits (libviprs-bench #36).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum LibvipsPinStatus {
-    /// The pin is the latest stable upstream release and its tarball SHA-256
-    /// still matches — nothing to do.
-    UpToDate,
-    /// A stable upstream release strictly newer than the pin exists.
-    NewerReleaseAvailable {
-        /// Latest stable upstream version, `"major.minor.patch"` — the bump
-        /// target an operator sees.
-        latest: String,
-    },
-    /// The pinned release's upstream tarball digest no longer matches
-    /// [`PINNED_LIBVIPS_SHA256`] — upstream re-published the asset, or the
-    /// recorded digest is wrong. The integrity signal; reported ahead of a mere
-    /// version bump so a re-cut pinned tarball is never masked by "there is a
-    /// newer version anyway".
-    Sha256Mismatch {
-        /// The recorded pin (the `pinned_sha256` argument).
-        pinned: String,
-        /// The digest the upstream release now advertises for the pinned tarball.
-        upstream: String,
-    },
-    /// The pinned release (or its `vips-<version>.tar.xz` asset with a digest)
-    /// was not found in the feed, so the SHA could not be validated —
-    /// indeterminate, not a pass. Mirrors [`OracleMatch::Indeterminate`]'s
-    /// "no verdict" role.
-    PinnedReleaseNotFound,
-}
-
-/// Why [`classify_libvips_pin`] could not reach a verdict from a payload.
-#[derive(Debug)]
-pub enum LibvipsPinError {
-    /// The payload was not valid JSON in the expected releases-array shape.
-    /// Carries the underlying `serde_json` message.
-    Parse(String),
-    /// The payload carried no stable (non-draft, non-pre-release) release, so
-    /// there is nothing to compare the pin against.
-    NoStableRelease,
-}
-
-impl std::fmt::Display for LibvipsPinError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Parse(e) => write!(f, "could not parse the releases payload: {e}"),
-            Self::NoStableRelease => write!(f, "the releases payload carried no stable release"),
-        }
-    }
-}
-
-impl std::error::Error for LibvipsPinError {}
-
-/// One GitHub release, trimmed to the fields the validator reads. Unknown
-/// fields are ignored, so the real API payload deserializes unchanged.
-#[derive(Deserialize)]
-struct GhRelease {
-    tag_name: String,
-    #[serde(default)]
-    draft: bool,
-    #[serde(default)]
-    prerelease: bool,
-    #[serde(default)]
-    assets: Vec<GhAsset>,
-}
-
-/// One release asset: its file name and (when the API provides it) the
-/// `"sha256:<hex>"` digest GitHub advertises for it.
-#[derive(Deserialize)]
-struct GhAsset {
-    name: String,
-    #[serde(default)]
-    digest: Option<String>,
-}
-
-/// Strip the `sha256:` scheme prefix GitHub asset digests carry.
-fn strip_sha256_prefix(digest: &str) -> &str {
-    digest.strip_prefix("sha256:").unwrap_or(digest)
-}
-
-/// Validate the recorded libvips pin (`pinned_version` / `pinned_sha256`,
-/// normally [`PINNED_LIBVIPS_VERSION`] / [`PINNED_LIBVIPS_SHA256`]) against a
-/// GitHub releases API payload (`GET /repos/libvips/libvips/releases`, a JSON
-/// array).
-///
-/// Host-independent and network-free: the caller supplies the payload — a
-/// captured sample in tests, a live `curl` fetch in the on-demand validator —
-/// so the same classification logic runs in both. Integrity beats freshness: a
-/// tarball digest that no longer matches upstream
-/// ([`LibvipsPinStatus::Sha256Mismatch`]) is reported ahead of a mere newer
-/// release, so a re-published pinned asset is never masked by a version bump.
-pub fn classify_libvips_pin(
-    releases_json: &str,
-    pinned_version: &str,
-    pinned_sha256: &str,
-) -> Result<LibvipsPinStatus, LibvipsPinError> {
-    let releases: Vec<GhRelease> =
-        serde_json::from_str(releases_json).map_err(|e| LibvipsPinError::Parse(e.to_string()))?;
-
-    // Latest *stable* release: drafts and pre-releases (e.g. `v8.18.3-rc1`) are
-    // never a bump target.
-    let latest_stable = releases
-        .iter()
-        .filter(|r| !r.draft && !r.prerelease)
-        .filter_map(|r| parse_libvips_version(&r.tag_name))
-        .max()
-        .ok_or(LibvipsPinError::NoStableRelease)?;
-
-    // Locate the pinned release's tarball digest, if the feed carries it.
-    let pinned_ver = parse_libvips_version(pinned_version);
-    let tarball = format!("vips-{pinned_version}.tar.xz");
-    let upstream_digest: Option<&str> = pinned_ver.and_then(|pv| {
-        releases
-            .iter()
-            .filter(|r| parse_libvips_version(&r.tag_name) == Some(pv))
-            .flat_map(|r| r.assets.iter())
-            .find(|a| a.name == tarball)
-            .and_then(|a| a.digest.as_deref())
-            .map(strip_sha256_prefix)
-    });
-
-    // Integrity first: a re-cut pinned tarball outranks a newer release.
-    if let Some(upstream) = upstream_digest.filter(|u| !u.eq_ignore_ascii_case(pinned_sha256)) {
-        return Ok(LibvipsPinStatus::Sha256Mismatch {
-            pinned: pinned_sha256.to_string(),
-            upstream: upstream.to_string(),
-        });
-    }
-
-    // Then freshness: a strictly newer stable release is a bump target.
-    if pinned_ver.is_some_and(|pv| latest_stable > pv) {
-        let (major, minor, patch) = latest_stable;
-        return Ok(LibvipsPinStatus::NewerReleaseAvailable {
-            latest: format!("{major}.{minor}.{patch}"),
-        });
-    }
-
-    // The pin is current, but its digest could not be located to confirm it.
-    if upstream_digest.is_none() {
-        return Ok(LibvipsPinStatus::PinnedReleaseNotFound);
-    }
-
-    Ok(LibvipsPinStatus::UpToDate)
 }
 
 /// Query the libvips version. Prefers the linked library's own

--- a/tests/fixtures/libvips_releases_sample.json
+++ b/tests/fixtures/libvips_releases_sample.json
@@ -1,0 +1,78 @@
+[
+  {
+    "tag_name": "v8.18.4",
+    "name": "v8.18.4",
+    "draft": false,
+    "prerelease": false,
+    "published_at": "2026-07-05T10:57:07Z",
+    "assets": [
+      {
+        "name": "vips-8.18.4.tar.xz",
+        "size": 25424116,
+        "digest": "sha256:2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037"
+      },
+      {
+        "name": "vips-8.18.4.tar.xz.sha256sum",
+        "size": 85,
+        "digest": "sha256:a5dde0950e2d22039ef61446d10e2adc3520ea971f6780c7492c0dfb8cea42e7"
+      }
+    ]
+  },
+  {
+    "tag_name": "v8.18.3",
+    "name": "v8.18.3",
+    "draft": false,
+    "prerelease": false,
+    "published_at": "2026-06-09T11:35:07Z",
+    "assets": [
+      {
+        "name": "vips-8.18.3.tar.xz",
+        "size": 25422084,
+        "digest": "sha256:f41285b61bfb495605494f074ca341f7791a1d406e2f157dcea606ef1ae1b146"
+      },
+      {
+        "name": "vips-8.18.3.tar.xz.sha256sum",
+        "size": 85,
+        "digest": "sha256:506c26f1414ef09bb1d8c5caa8f4a1e06135919ff9f19fad368c71c47dfa1b3a"
+      }
+    ]
+  },
+  {
+    "tag_name": "v8.18.3-rc1",
+    "name": "v8.18.3-rc1",
+    "draft": false,
+    "prerelease": true,
+    "published_at": "2026-06-06T13:33:52Z",
+    "assets": [
+      {
+        "name": "vips-8.18.3.tar.xz",
+        "size": 25420540,
+        "digest": "sha256:548e2de8f7c86d7bf19705edea51db9bf0c490cab23b9d10dcd3d8b20c1826c9"
+      },
+      {
+        "name": "vips-8.18.3.tar.xz.sha256sum",
+        "size": 85,
+        "digest": "sha256:3698e4254de1137f40df98ebbc6f4353f4f04c001b9a61c61ed7df9e196199d7"
+      }
+    ]
+  },
+  {
+    "tag_name": "v8.18.2",
+    "name": "v8.18.2",
+    "draft": false,
+    "prerelease": false,
+    "published_at": "2026-03-31T21:36:16Z",
+    "assets": [
+      {
+        "name": "vips-8.18.2.tar.xz",
+        "size": 25429028,
+        "digest": "sha256:a30d4aede16f1c2899c1a2241870f8a7409feafa38484bcdcdac113d6d6f8ff5"
+      },
+      {
+        "name": "vips-8.18.2.tar.xz.sha256sum",
+        "size": 85,
+        "digest": "sha256:0a2039f89f21acd62628cd67c5f83198ddc264cc62ccbfb64ded20b03ba310da"
+      }
+    ]
+  }
+]

--- a/tests/libvips_provenance.rs
+++ b/tests/libvips_provenance.rs
@@ -14,6 +14,12 @@
 //! provenance constant) and fail the moment the pin drifts or the Dockerfile
 //! regresses to an unpinned / apt-installed libvips — without needing Docker
 //! or libvips in the loop.
+//!
+//! Sub-issue #35 extends the same reproducibility guard to the rest of the
+//! build environment: the base images must be digest-pinned (`FROM …@sha256:`)
+//! and the apt toolchain (libpng et al. — the DeepZoom PNG hot path) pinned to
+//! a dated `snapshot.debian.org` mirror, so no layer floats on a live tag or a
+//! live mirror between benchmark runs.
 
 use libviprs_bench::provenance::{
     OracleMatch, PINNED_LIBVIPS_SHA256, PINNED_LIBVIPS_VERSION, Provenance,
@@ -250,6 +256,80 @@ fn dockerfile_asserts_built_libvips_version_equals_pin() {
     );
 }
 
+/// #35 (Dockerfile reproducibility): every base image must be *digest*-pinned
+/// (`FROM …@sha256:<64-hex>`), not left on a floating tag. A tag can be re-cut
+/// upstream to point at different bytes; a digest fixes the exact base layer so
+/// it cannot shift under a rebuild.
+#[test]
+fn dockerfile_digest_pins_base_images() {
+    let froms: Vec<&str> = DOCKERFILE
+        .lines()
+        .filter(|line| line.trim_start().starts_with("FROM "))
+        .collect();
+    assert!(!froms.is_empty(), "Dockerfile must declare FROM stages");
+    for from in &froms {
+        assert!(
+            from.contains("@sha256:"),
+            "every base image must be digest-pinned for reproducibility (#35); \
+             `{}` is not",
+            from.trim()
+        );
+        assert!(
+            has_wellformed_sha256_digest(from),
+            "`{}` must carry a well-formed 64-hex `@sha256:` digest, not a \
+             placeholder (#35)",
+            from.trim()
+        );
+    }
+}
+
+/// #35: the apt build toolchain (libpng, glib, jpeg, tiff, webp, expat `-dev`)
+/// must be pinned to a dated `snapshot.debian.org` mirror, not resolved against
+/// the live bookworm mirror where an intra-suite point release (e.g. a libpng
+/// security update) can shift the encode hot path under a rebuild. This is
+/// exactly the float the #24 scope note deferred to #35.
+#[test]
+fn dockerfile_pins_apt_to_a_debian_snapshot() {
+    let instructions = dockerfile_instructions(DOCKERFILE);
+    assert!(
+        instructions.contains("snapshot.debian.org/archive/debian"),
+        "Dockerfile must point apt at a snapshot.debian.org archive so the codec \
+         `-dev` libraries resolve to fixed versions, not the live mirror (#35)"
+    );
+    // A concrete, well-formed snapshot timestamp (YYYYMMDDThhmmssZ), not a bare
+    // archive root that would still float.
+    assert!(
+        contains_snapshot_timestamp(&instructions),
+        "the snapshot.debian.org URL must carry a dated timestamp \
+         (e.g. 20250929T000000Z), not a floating archive root (#35)"
+    );
+    // Snapshot Release files carry an old `Valid-Until`; apt must be told to
+    // accept them or `apt-get update` rejects the dated snapshot outright.
+    assert!(
+        instructions.contains("Check-Valid-Until"),
+        "apt must set `Acquire::Check-Valid-Until false` to read a dated \
+         snapshot (#35)"
+    );
+}
+
+/// #35 consistency: the apt snapshot and the digest-pinned Debian base must
+/// describe the *same* point in time. The base image tag encodes its build date
+/// (`bookworm-YYYYMMDD`) and Debian embeds the matching snapshot, so the
+/// snapshot timestamp must carry that same date — one frozen point for the whole
+/// image, not two that can drift apart.
+#[test]
+fn apt_snapshot_matches_the_pinned_base_image_date() {
+    let base = base_image_date(DOCKERFILE)
+        .expect("a Debian base image must carry a `bookworm-YYYYMMDD` date (#35)");
+    let snap = snapshot_date(&dockerfile_instructions(DOCKERFILE))
+        .expect("the apt snapshot must carry a `YYYYMMDD` timestamp (#35)");
+    assert_eq!(
+        base, snap,
+        "the apt snapshot date ({snap}) must match the pinned Debian base image \
+         date ({base}) so the whole image is one frozen point in time (#35)"
+    );
+}
+
 /// Dockerfile text with `#` comment lines stripped, so *negative* assertions
 /// target build instructions rather than explanatory prose (a comment may
 /// still name the ~8.14 apt oracle the source build replaces).
@@ -291,4 +371,53 @@ fn cargo_libvips_rs_req(cargo: &str) -> Option<String> {
             .trim_start_matches(['=', '^', '~', '>', '<', ' '])
             .to_string(),
     )
+}
+
+/// Whether a `FROM` line carries a well-formed `@sha256:<64 hex>` digest pin.
+fn has_wellformed_sha256_digest(line: &str) -> bool {
+    match line.split_once("@sha256:") {
+        Some((_, rest)) => {
+            let hex = rest
+                .chars()
+                .take_while(|c| c.is_ascii_hexdigit())
+                .count();
+            hex == 64
+        }
+        None => false,
+    }
+}
+
+/// Whether `text` contains a `snapshot.debian.org` timestamp token
+/// (`YYYYMMDDThhmmssZ`, e.g. `20250929T000000Z`).
+fn contains_snapshot_timestamp(text: &str) -> bool {
+    text.split(|c: char| !c.is_ascii_alphanumeric())
+        .any(is_snapshot_timestamp)
+}
+
+/// Match a single `YYYYMMDDThhmmssZ` snapshot timestamp token.
+fn is_snapshot_timestamp(token: &str) -> bool {
+    let b = token.as_bytes();
+    b.len() == 16
+        && b[..8].iter().all(u8::is_ascii_digit)
+        && b[8] == b'T'
+        && b[9..15].iter().all(u8::is_ascii_digit)
+        && b[15] == b'Z'
+}
+
+/// Extract the `YYYYMMDD` date from the first `bookworm-YYYYMMDD` base-image tag
+/// (the dated Debian image); ignores undated `-bookworm` tags and the
+/// `bookworm-updates` / `bookworm-security` suite names.
+fn base_image_date(dockerfile: &str) -> Option<String> {
+    dockerfile.split("bookworm-").skip(1).find_map(|rest| {
+        let date: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        (date.len() == 8).then_some(date)
+    })
+}
+
+/// Extract the `YYYYMMDD` prefix of the `snapshot.debian.org` timestamp token.
+fn snapshot_date(dockerfile: &str) -> Option<String> {
+    dockerfile
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .find(|token| is_snapshot_timestamp(token))
+        .map(|token| token[..8].to_string())
 }

--- a/tests/libvips_provenance.rs
+++ b/tests/libvips_provenance.rs
@@ -46,9 +46,11 @@ fn recorded_libvips_version_parses_to_expected_major_minor() {
         "the pinned libvips must be on the 8.18 series the bindings target (#33)"
     );
 
-    // Raw `vips --version` output ("vips-8.18.4") parses identically to the
-    // `vips-`-stripped form provenance stores ("8.18.4").
+    // Raw `vips --version` output ("vips-8.18.4"), a GitHub tag ("v8.18"), and
+    // the `vips-`-stripped form provenance stores ("8.18.4") all parse
+    // identically — prefix handling is shared with `pin_check`'s triple parser.
     assert_eq!(parse_libvips_major_minor("vips-8.18.4"), Some((8, 18)));
+    assert_eq!(parse_libvips_major_minor("v8.18"), Some((8, 18)));
     assert_eq!(parse_libvips_major_minor("8.18.4"), Some((8, 18)));
     assert_eq!(
         parse_libvips_major_minor("vips-8.18.4"),
@@ -319,9 +321,13 @@ fn dockerfile_pins_apt_to_a_debian_snapshot() {
 /// image, not two that can drift apart.
 #[test]
 fn apt_snapshot_matches_the_pinned_base_image_date() {
-    let base = base_image_date(DOCKERFILE)
+    // Both dates are read from the comment-stripped build instructions, so the
+    // `(bookworm-20250929)` mention in the header prose can never stand in for
+    // the real `FROM` tag.
+    let instructions = dockerfile_instructions(DOCKERFILE);
+    let base = base_image_date(&instructions)
         .expect("a Debian base image must carry a `bookworm-YYYYMMDD` date (#35)");
-    let snap = snapshot_date(&dockerfile_instructions(DOCKERFILE))
+    let snap = snapshot_date(&instructions)
         .expect("the apt snapshot must carry a `YYYYMMDD` timestamp (#35)");
     assert_eq!(
         base, snap,
@@ -404,6 +410,11 @@ fn is_snapshot_timestamp(token: &str) -> bool {
 /// Extract the `YYYYMMDD` date from the first `bookworm-YYYYMMDD` base-image tag
 /// (the dated Debian image); ignores undated `-bookworm` tags and the
 /// `bookworm-updates` / `bookworm-security` suite names.
+///
+/// Reads the date from the base image's *tag* string, not its `@sha256:`
+/// digest: a digest's build date is not knowable offline, so this asserts the
+/// tag and the apt snapshot describe the same day. Feed it the comment-stripped
+/// [`dockerfile_instructions`] so it reads the real `FROM` tag, not header prose.
 fn base_image_date(dockerfile: &str) -> Option<String> {
     dockerfile.split("bookworm-").skip(1).find_map(|rest| {
         let date: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();

--- a/tests/libvips_provenance.rs
+++ b/tests/libvips_provenance.rs
@@ -377,10 +377,7 @@ fn cargo_libvips_rs_req(cargo: &str) -> Option<String> {
 fn has_wellformed_sha256_digest(line: &str) -> bool {
     match line.split_once("@sha256:") {
         Some((_, rest)) => {
-            let hex = rest
-                .chars()
-                .take_while(|c| c.is_ascii_hexdigit())
-                .count();
+            let hex = rest.chars().take_while(|c| c.is_ascii_hexdigit()).count();
             hex == 64
         }
         None => false,

--- a/tests/libvips_upstream_check.rs
+++ b/tests/libvips_upstream_check.rs
@@ -169,8 +169,12 @@ fn classify_errors_on_malformed_payload() {
 /// `tests/fixtures/libvips_releases_sample.json` in the same edit.
 #[test]
 fn recorded_pin_matches_the_captured_upstream_sample() {
-    let status = classify_libvips_pin(RELEASES_SAMPLE, PINNED_LIBVIPS_VERSION, PINNED_LIBVIPS_SHA256)
-        .expect("captured sample classifies against the recorded pin");
+    let status = classify_libvips_pin(
+        RELEASES_SAMPLE,
+        PINNED_LIBVIPS_VERSION,
+        PINNED_LIBVIPS_SHA256,
+    )
+    .expect("captured sample classifies against the recorded pin");
     assert_eq!(
         status,
         LibvipsPinStatus::UpToDate,

--- a/tests/libvips_upstream_check.rs
+++ b/tests/libvips_upstream_check.rs
@@ -1,0 +1,231 @@
+//! On-demand upstream-pin validator (libviprs-bench #36).
+//!
+//! The libvips oracle is pinned by version + SHA-256 (`provenance::
+//! PINNED_LIBVIPS_VERSION` / `PINNED_LIBVIPS_SHA256`, built from source by the
+//! Dockerfile). A pin ages silently: upstream ships a newer release, or —
+//! worse — re-cuts the pinned tarball so the recorded digest no longer matches
+//! the bytes served. This validator flags both against the upstream GitHub
+//! releases feed. It is deliberately *on-demand* (a `tools/` script plus an
+//! `#[ignore]`d live test), never a PR gate: this repo gates locally and skips
+//! GitHub CI on PR commits.
+//!
+//! These are cheap, host-independent checks in the style of
+//! `tests/libvips_provenance.rs` / `tests/pdfium_provenance.rs`: the
+//! classification logic runs over a *captured* releases payload
+//! (`tests/fixtures/libvips_releases_sample.json`, a trimmed real
+//! `GET /repos/libvips/libvips/releases` response) so no network is touched.
+//! One `#[ignore]`d test performs the real fetch on demand.
+
+use libviprs_bench::provenance::{
+    LibvipsPinError, LibvipsPinStatus, PINNED_LIBVIPS_SHA256, PINNED_LIBVIPS_VERSION,
+    classify_libvips_pin, parse_libvips_version,
+};
+
+/// Trimmed, real `GET /repos/libvips/libvips/releases` payload captured
+/// 2026-07-20: `v8.18.4` (the pinned/latest stable), `v8.18.3`, `v8.18.3-rc1`
+/// (a pre-release, present to prove it is skipped), and `v8.18.2`. Each asset
+/// `digest` is the upstream SHA-256 verbatim. Re-capture it whenever the pin is
+/// bumped (see [`recorded_pin_matches_the_captured_upstream_sample`]).
+const RELEASES_SAMPLE: &str = include_str!("fixtures/libvips_releases_sample.json");
+
+/// Upstream `vips-8.18.4.tar.xz` digest carried by the sample (equals the
+/// recorded [`PINNED_LIBVIPS_SHA256`]), spelled out so the classification cases
+/// read explicitly rather than reaching back into the JSON.
+const V8_18_4_SHA256: &str = "2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037";
+/// Upstream `vips-8.18.3.tar.xz` digest carried by the sample.
+const V8_18_3_SHA256: &str = "f41285b61bfb495605494f074ca341f7791a1d406e2f157dcea606ef1ae1b146";
+
+/// The version parser reads the GitHub tag form, the `vips --version` line, and
+/// the bare pin, and rejects pre-releases so an `-rc` is never a bump target.
+#[test]
+fn parse_libvips_version_reads_tag_cli_and_bare_forms() {
+    assert_eq!(parse_libvips_version("v8.18.4"), Some((8, 18, 4))); // GitHub tag
+    assert_eq!(parse_libvips_version("vips-8.18.4"), Some((8, 18, 4))); // CLI line
+    assert_eq!(parse_libvips_version("8.18.4"), Some((8, 18, 4))); // bare pin
+
+    // The strict ordering the newer-release check relies on.
+    assert!(parse_libvips_version("v8.18.4") > parse_libvips_version("v8.18.3"));
+    assert!(parse_libvips_version("v8.19.0") > parse_libvips_version("v8.18.4"));
+    assert!(parse_libvips_version("v9.0.0") > parse_libvips_version("v8.18.4"));
+
+    // A pre-release tag has no finished-release version, so it can never be
+    // selected as "latest" — neither can the `"unknown"` sentinel or junk.
+    assert_eq!(parse_libvips_version("v8.18.3-rc1"), None);
+    assert_eq!(parse_libvips_version("unknown"), None);
+    assert_eq!(parse_libvips_version(""), None);
+}
+
+/// Match case: the pin is the latest stable release AND its tarball digest
+/// still matches upstream → nothing to do.
+#[test]
+fn classify_reports_up_to_date_when_pin_is_latest_and_matches() {
+    let status = classify_libvips_pin(RELEASES_SAMPLE, "8.18.4", V8_18_4_SHA256)
+        .expect("sample payload classifies");
+    assert_eq!(status, LibvipsPinStatus::UpToDate);
+}
+
+/// Newer-release case: pinned to `8.18.3` while `8.18.4` is the latest stable
+/// in the feed → flag the bump target.
+#[test]
+fn classify_flags_a_newer_stable_release() {
+    let status = classify_libvips_pin(RELEASES_SAMPLE, "8.18.3", V8_18_3_SHA256)
+        .expect("sample payload classifies");
+    assert_eq!(
+        status,
+        LibvipsPinStatus::NewerReleaseAvailable {
+            latest: "8.18.4".to_string()
+        }
+    );
+}
+
+/// A pre-release strictly newer than the pin must NOT be offered as a bump: the
+/// feed here carries a `v9.0.0-rc1` pre-release above the stable `8.18.4` pin,
+/// yet the verdict stays [`LibvipsPinStatus::UpToDate`].
+#[test]
+fn classify_ignores_a_higher_prerelease() {
+    let feed = format!(
+        r#"[
+            {{"tag_name":"v9.0.0-rc1","draft":false,"prerelease":true,
+              "assets":[{{"name":"vips-9.0.0.tar.xz","digest":"sha256:{V8_18_4_SHA256}"}}]}},
+            {{"tag_name":"v8.18.4","draft":false,"prerelease":false,
+              "assets":[{{"name":"vips-8.18.4.tar.xz","digest":"sha256:{V8_18_4_SHA256}"}}]}}
+        ]"#
+    );
+    let status = classify_libvips_pin(&feed, "8.18.4", V8_18_4_SHA256).expect("feed classifies");
+    assert_eq!(
+        status,
+        LibvipsPinStatus::UpToDate,
+        "a pre-release must never be selected as the latest stable (would false-flag a bump)"
+    );
+}
+
+/// SHA-mismatch case: same pinned version, but a recorded digest that no longer
+/// matches the upstream tarball — upstream re-published, or the pin is wrong.
+#[test]
+fn classify_flags_a_sha256_mismatch() {
+    let wrong = "0000000000000000000000000000000000000000000000000000000000000000";
+    let status =
+        classify_libvips_pin(RELEASES_SAMPLE, "8.18.4", wrong).expect("sample payload classifies");
+    assert_eq!(
+        status,
+        LibvipsPinStatus::Sha256Mismatch {
+            pinned: wrong.to_string(),
+            upstream: V8_18_4_SHA256.to_string(),
+        }
+    );
+}
+
+/// Integrity beats freshness: pinned to `8.18.3` (behind `8.18.4`) AND its
+/// recorded digest is wrong — the mismatch is reported ahead of the newer
+/// release, so a re-published pinned tarball is never masked by "there is a
+/// newer version anyway".
+#[test]
+fn integrity_mismatch_is_reported_ahead_of_a_newer_release() {
+    let wrong = "1111111111111111111111111111111111111111111111111111111111111111";
+    let status =
+        classify_libvips_pin(RELEASES_SAMPLE, "8.18.3", wrong).expect("sample payload classifies");
+    assert_eq!(
+        status,
+        LibvipsPinStatus::Sha256Mismatch {
+            pinned: wrong.to_string(),
+            upstream: V8_18_3_SHA256.to_string(),
+        }
+    );
+}
+
+/// A pin newer than anything upstream (or dropped from the feed window): the
+/// digest cannot be validated and there is no newer release, so the verdict is
+/// the indeterminate [`LibvipsPinStatus::PinnedReleaseNotFound`] — not a pass.
+#[test]
+fn classify_flags_a_pin_missing_from_the_feed() {
+    let status = classify_libvips_pin(RELEASES_SAMPLE, "8.99.0", V8_18_4_SHA256)
+        .expect("sample payload classifies");
+    assert_eq!(status, LibvipsPinStatus::PinnedReleaseNotFound);
+}
+
+/// A feed with no stable release at all yields an error, not a false verdict.
+#[test]
+fn classify_errors_when_no_stable_release_present() {
+    let only_pre = r#"[{"tag_name":"v9.0.0-rc1","prerelease":true,"assets":[]}]"#;
+    assert!(matches!(
+        classify_libvips_pin(only_pre, "8.18.4", V8_18_4_SHA256),
+        Err(LibvipsPinError::NoStableRelease)
+    ));
+}
+
+/// A malformed payload is a typed parse error, never a panic or a silent pass.
+#[test]
+fn classify_errors_on_malformed_payload() {
+    assert!(matches!(
+        classify_libvips_pin("{not json", "8.18.4", V8_18_4_SHA256),
+        Err(LibvipsPinError::Parse(_))
+    ));
+}
+
+/// The #36 drift guard: the committed pin (the `provenance` constants) must
+/// agree with a real upstream releases payload — right version, right digest,
+/// and the latest stable at capture time. This is exactly the drift #36 exists
+/// to catch. When the pin is bumped, re-capture
+/// `tests/fixtures/libvips_releases_sample.json` in the same edit.
+#[test]
+fn recorded_pin_matches_the_captured_upstream_sample() {
+    let status = classify_libvips_pin(RELEASES_SAMPLE, PINNED_LIBVIPS_VERSION, PINNED_LIBVIPS_SHA256)
+        .expect("captured sample classifies against the recorded pin");
+    assert_eq!(
+        status,
+        LibvipsPinStatus::UpToDate,
+        "recorded libvips pin ({PINNED_LIBVIPS_VERSION}) disagrees with the captured upstream \
+         releases sample; if the pin was bumped, re-capture the fixture in the same edit"
+    );
+}
+
+/// The committed on-demand validator script must query the upstream feed and
+/// read the pin from the single source of truth (provenance.rs), not a copy
+/// that can silently drift. Cheap source-level guard, no network.
+#[test]
+fn on_demand_validator_script_is_well_formed() {
+    const SCRIPT: &str = include_str!("../tools/check-libvips-pin.sh");
+    assert!(
+        SCRIPT.contains("api.github.com/repos/libvips/libvips/releases"),
+        "validator must query the upstream libvips releases API (#36)"
+    );
+    assert!(
+        SCRIPT.contains("PINNED_LIBVIPS_VERSION") && SCRIPT.contains("PINNED_LIBVIPS_SHA256"),
+        "validator must read the pin from provenance.rs so the two cannot drift (#36)"
+    );
+}
+
+/// On-demand live validation against the real upstream feed. Ignored by
+/// default (needs network + `curl`); run explicitly:
+///
+/// ```text
+/// cargo test --test libvips_upstream_check -- --ignored
+/// ```
+///
+/// A failure means the pinned libvips has genuinely aged (a newer release) or
+/// its tarball digest drifted — refresh the pin (and the captured fixture).
+#[test]
+#[ignore = "hits the live GitHub releases API; run explicitly with --ignored"]
+fn live_upstream_pin_is_current() {
+    let out = std::process::Command::new("curl")
+        .args([
+            "-fsSL",
+            "-H",
+            "Accept: application/vnd.github+json",
+            "https://api.github.com/repos/libvips/libvips/releases?per_page=20",
+        ])
+        .output()
+        .expect("curl must be available to run the live check");
+    assert!(
+        out.status.success(),
+        "curl fetch of the upstream releases feed failed"
+    );
+    let json = String::from_utf8(out.stdout).expect("releases feed is UTF-8");
+    let status = classify_libvips_pin(&json, PINNED_LIBVIPS_VERSION, PINNED_LIBVIPS_SHA256)
+        .expect("live releases feed classifies");
+    assert_eq!(
+        status,
+        LibvipsPinStatus::UpToDate,
+        "pinned libvips {PINNED_LIBVIPS_VERSION} is no longer current upstream: {status:?}"
+    );
+}

--- a/tests/libvips_upstream_check.rs
+++ b/tests/libvips_upstream_check.rs
@@ -5,9 +5,11 @@
 //! Dockerfile). A pin ages silently: upstream ships a newer release, or —
 //! worse — re-cuts the pinned tarball so the recorded digest no longer matches
 //! the bytes served. This validator flags both against the upstream GitHub
-//! releases feed. It is deliberately *on-demand* (a `tools/` script plus an
-//! `#[ignore]`d live test), never a PR gate: this repo gates locally and skips
-//! GitHub CI on PR commits.
+//! releases feed. It is deliberately *on-demand* (a `tools/` script that pipes
+//! the feed to the `check-libvips-pin` binary, plus an `#[ignore]`d live test),
+//! never a PR gate: this repo gates locally and skips GitHub CI on PR commits.
+//! The script, the binary, and the live test all call the one
+//! `pin_check::classify_libvips_pin` — there is no parallel classifier.
 //!
 //! These are cheap, host-independent checks in the style of
 //! `tests/libvips_provenance.rs` / `tests/pdfium_provenance.rs`: the
@@ -16,7 +18,7 @@
 //! `GET /repos/libvips/libvips/releases` response) so no network is touched.
 //! One `#[ignore]`d test performs the real fetch on demand.
 
-use libviprs_bench::provenance::{
+use libviprs_bench::pin_check::{
     LibvipsPinError, LibvipsPinStatus, PINNED_LIBVIPS_SHA256, PINNED_LIBVIPS_VERSION,
     classify_libvips_pin, parse_libvips_version,
 };
@@ -162,10 +164,13 @@ fn classify_errors_on_malformed_payload() {
     ));
 }
 
-/// The #36 drift guard: the committed pin (the `provenance` constants) must
-/// agree with a real upstream releases payload — right version, right digest,
-/// and the latest stable at capture time. This is exactly the drift #36 exists
-/// to catch. When the pin is bumped, re-capture
+/// Commit-time consistency guard: the committed pin (the `provenance`
+/// constants) must agree with the committed upstream sample — right version,
+/// right digest, latest stable at capture time. Because the pin and the fixture
+/// are committed together and agree by construction, this can only ever catch a
+/// copy-paste slip at commit time; it does NOT detect a pin aging against *live*
+/// upstream — that is the job of [`live_upstream_pin_is_current`] and
+/// `tools/check-libvips-pin.sh`. When the pin is bumped, re-capture
 /// `tests/fixtures/libvips_releases_sample.json` in the same edit.
 #[test]
 fn recorded_pin_matches_the_captured_upstream_sample() {
@@ -183,19 +188,74 @@ fn recorded_pin_matches_the_captured_upstream_sample() {
     );
 }
 
-/// The committed on-demand validator script must query the upstream feed and
-/// read the pin from the single source of truth (provenance.rs), not a copy
-/// that can silently drift. Cheap source-level guard, no network.
+/// The committed on-demand validator script must fetch the upstream feed and
+/// delegate classification to the single-source `check-libvips-pin` binary
+/// (which calls [`classify_libvips_pin`]), never reimplement it shell-side. A
+/// parallel jq/bash classifier is exactly what diverged from the Rust logic in
+/// the #35/#36 review (a null digest read as a false MISMATCH; a mis-flagged
+/// pre-release ranked as "latest"). Cheap source-level guard, no network.
 #[test]
-fn on_demand_validator_script_is_well_formed() {
+fn on_demand_validator_script_delegates_to_the_single_classifier() {
     const SCRIPT: &str = include_str!("../tools/check-libvips-pin.sh");
     assert!(
         SCRIPT.contains("api.github.com/repos/libvips/libvips/releases"),
         "validator must query the upstream libvips releases API (#36)"
     );
     assert!(
-        SCRIPT.contains("PINNED_LIBVIPS_VERSION") && SCRIPT.contains("PINNED_LIBVIPS_SHA256"),
-        "validator must read the pin from provenance.rs so the two cannot drift (#36)"
+        SCRIPT.contains("--bin check-libvips-pin"),
+        "validator must pipe the feed to the `check-libvips-pin` binary so the \
+         single `classify_libvips_pin` is the only classifier (#36)"
+    );
+    // Guard against a regression to a parallel shell-side classifier: the old
+    // jq `sort_by` "latest stable" ranking is precisely what diverged.
+    assert!(
+        !SCRIPT.contains("sort_by"),
+        "the shell must not re-derive 'latest stable' itself; that jq ranking \
+         diverged from `classify_libvips_pin` (#35/#36 review)"
+    );
+}
+
+/// The version compare and the tarball-digest lookup must agree on the input
+/// form. A `v`- or `vips-`-prefixed pin (both accepted by
+/// [`parse_libvips_version`]) must still locate the
+/// `vips-<major.minor.patch>.tar.xz` asset and validate — the pre-review code
+/// built the asset name from the raw argument, so a `v8.18.4` pin produced
+/// `vips-v8.18.4.tar.xz`, matched nothing, and read as a false
+/// `PinnedReleaseNotFound` for a perfectly valid pin.
+#[test]
+fn classify_validates_prefixed_pin_forms() {
+    for pin in ["v8.18.4", "vips-8.18.4", "8.18.4"] {
+        let status = classify_libvips_pin(RELEASES_SAMPLE, pin, V8_18_4_SHA256)
+            .unwrap_or_else(|e| panic!("sample classifies for pin {pin}: {e}"));
+        assert_eq!(
+            status,
+            LibvipsPinStatus::UpToDate,
+            "pin form {pin} must normalize and validate, not read as not-found"
+        );
+    }
+}
+
+/// Only a finished stable release may supply the digest the pin is validated
+/// against. Here a `draft:true` `v8.18.4` carrying a bogus digest precedes the
+/// real stable `v8.18.4` in document order; the verdict must stay
+/// [`LibvipsPinStatus::UpToDate`], not a false `Sha256Mismatch` driven by the
+/// draft's digest (the pre-review lookup filtered on version only).
+#[test]
+fn classify_ignores_a_draft_same_version_digest() {
+    let bogus = "dead".repeat(16); // 64-hex, != the real v8.18.4 digest
+    let feed = format!(
+        r#"[
+            {{"tag_name":"v8.18.4","draft":true,"prerelease":false,
+              "assets":[{{"name":"vips-8.18.4.tar.xz","digest":"sha256:{bogus}"}}]}},
+            {{"tag_name":"v8.18.4","draft":false,"prerelease":false,
+              "assets":[{{"name":"vips-8.18.4.tar.xz","digest":"sha256:{V8_18_4_SHA256}"}}]}}
+        ]"#
+    );
+    let status = classify_libvips_pin(&feed, "8.18.4", V8_18_4_SHA256).expect("feed classifies");
+    assert_eq!(
+        status,
+        LibvipsPinStatus::UpToDate,
+        "a draft release's digest must never drive the pin verdict"
     );
 }
 

--- a/tools/check-libvips-pin.sh
+++ b/tools/check-libvips-pin.sh
@@ -8,96 +8,50 @@ set -euo pipefail
 # (`provenance::PINNED_LIBVIPS_VERSION` / `PINNED_LIBVIPS_SHA256`, built from a
 # source tarball by the Dockerfile — issue #33). A pin ages silently: upstream
 # ships a newer release, or re-cuts the pinned tarball so the recorded digest no
-# longer matches the bytes served. This script flags both against the upstream
+# longer matches the bytes served. This check flags both against the upstream
 # GitHub releases feed.
+#
+# It is a THIN wrapper. It only fetches the feed with `curl` and pipes it to the
+# `check-libvips-pin` binary, which runs the one and only classifier
+# (`pin_check::classify_libvips_pin`) over the recorded pin and maps the verdict
+# to an exit code. There is NO second, shell-side reimplementation to drift from
+# the Rust logic: the binary reads the pin constants at compile time, and the
+# unit tests exercise that same `classify_libvips_pin`.
 #
 # It is deliberately ON-DEMAND — never a PR gate. This repo gates locally and
 # skips GitHub CI on PR commits; run it by hand before a pin bump, or wire it
-# into a NON-gating daily cron. It shares the exact classification the
-# in-process validator uses (`provenance::classify_libvips_pin`), exercised in
-# `tests/libvips_upstream_check.rs`.
+# into a NON-gating daily cron that alerts on a non-zero exit.
 #
 # Usage:  ./tools/check-libvips-pin.sh
-# Needs:  curl, jq (the same tools the Docker path and fixtures already use).
+# Needs:  curl (fetch) and cargo (runs the classifier binary).
 # Exit:   0 up-to-date · 1 newer release or digest mismatch · 2 could not check.
 # ---------------------------------------------------------------------------
 
 API="https://api.github.com/repos/libvips/libvips/releases?per_page=20"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROVENANCE="${SCRIPT_DIR}/../src/provenance.rs"
+MANIFEST="${SCRIPT_DIR}/../Cargo.toml"
 
-for tool in curl jq; do
+for tool in curl cargo; do
     if ! command -v "$tool" >/dev/null 2>&1; then
         echo "Error: '${tool}' is required but not installed." >&2
         exit 2
     fi
 done
 
-# Read the pin from the single source of truth (provenance.rs) so this check
-# and the recorded constants can never drift apart. Tolerates the value sitting
-# on the next line (rustfmt wraps the long SHA-256 literal).
-extract_const() {
-    tr '\n' ' ' <"$PROVENANCE" \
-        | grep -oE "pub const $1: &str =[^\"]*\"[0-9A-Za-z.]+\"" \
-        | grep -oE '"[0-9A-Za-z.]+"' \
-        | tr -d '"' \
-        | head -1
-}
-
-PINNED_LIBVIPS_VERSION="$(extract_const PINNED_LIBVIPS_VERSION)"
-PINNED_LIBVIPS_SHA256="$(extract_const PINNED_LIBVIPS_SHA256)"
-
-if [ -z "$PINNED_LIBVIPS_VERSION" ] || [ -z "$PINNED_LIBVIPS_SHA256" ]; then
-    echo "Error: could not read the pin from ${PROVENANCE}." >&2
-    exit 2
-fi
-
-echo "Pinned libvips: ${PINNED_LIBVIPS_VERSION} (sha256 ${PINNED_LIBVIPS_SHA256})"
-echo "Querying ${API} ..."
+echo "Querying ${API} ..." >&2
 
 RELEASES="$(curl -fsSL -H 'Accept: application/vnd.github+json' "$API")" || {
     echo "Error: could not fetch the upstream releases feed." >&2
     exit 2
 }
 
-# Latest stable release (skip drafts and pre-releases), tag stripped of `v` and
-# ordered by numeric (major, minor, patch).
-LATEST="$(printf '%s' "$RELEASES" \
-    | jq -r '[.[] | select(.draft == false and .prerelease == false)
-                  | .tag_name | ltrimstr("v")]
-             | sort_by(split(".") | map(tonumber? // 0)) | last // empty')"
-
-# Upstream digest of the pinned tarball, if the feed still carries it.
-UPSTREAM_SHA="$(printf '%s' "$RELEASES" \
-    | jq -r --arg v "$PINNED_LIBVIPS_VERSION" \
-        '.[] | select((.tag_name | ltrimstr("v")) == $v)
-             | .assets[]? | select(.name == "vips-\($v).tar.xz")
-             | .digest | ltrimstr("sha256:")' \
-    | head -1)"
-
-status=0
-
-# Integrity first: a re-cut pinned tarball outranks a mere newer release.
-if [ -n "$UPSTREAM_SHA" ] && [ "$UPSTREAM_SHA" != "$PINNED_LIBVIPS_SHA256" ]; then
-    echo "MISMATCH: upstream vips-${PINNED_LIBVIPS_VERSION}.tar.xz is now ${UPSTREAM_SHA}," >&2
-    echo "          but the pin records ${PINNED_LIBVIPS_SHA256}." >&2
-    status=1
-elif [ -z "$UPSTREAM_SHA" ]; then
-    echo "WARNING: vips-${PINNED_LIBVIPS_VERSION}.tar.xz not found in the feed; digest unverified." >&2
-fi
-
-# Then freshness: a strictly newer latest stable is a bump target.
-if [ -n "$LATEST" ] && [ "$LATEST" != "$PINNED_LIBVIPS_VERSION" ]; then
-    newest="$(printf '%s\n%s\n' "$PINNED_LIBVIPS_VERSION" "$LATEST" \
-        | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)"
-    if [ "$newest" = "$LATEST" ]; then
-        echo "NEWER RELEASE: upstream latest stable is ${LATEST} (pinned ${PINNED_LIBVIPS_VERSION})."
-        status=1
-    fi
-fi
-
-if [ "$status" -eq 0 ]; then
-    echo "OK: pinned libvips ${PINNED_LIBVIPS_VERSION} is the latest stable and its SHA-256 matches upstream."
-fi
-exit "$status"
+# Hand the payload to the single classifier. The binary prints the verdict and
+# sets the exit code (0 up-to-date, 1 drift, 2 could-not-check); propagate it
+# rather than re-deriving anything here.
+set +e
+printf '%s' "$RELEASES" \
+    | cargo run --quiet --manifest-path "$MANIFEST" --bin check-libvips-pin
+code=$?
+set -e
+exit "$code"

--- a/tools/check-libvips-pin.sh
+++ b/tools/check-libvips-pin.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# check-libvips-pin.sh — validate the pinned libvips against upstream (#36)
+#
+# The benchmark oracle is pinned by version + SHA-256
+# (`provenance::PINNED_LIBVIPS_VERSION` / `PINNED_LIBVIPS_SHA256`, built from a
+# source tarball by the Dockerfile — issue #33). A pin ages silently: upstream
+# ships a newer release, or re-cuts the pinned tarball so the recorded digest no
+# longer matches the bytes served. This script flags both against the upstream
+# GitHub releases feed.
+#
+# It is deliberately ON-DEMAND — never a PR gate. This repo gates locally and
+# skips GitHub CI on PR commits; run it by hand before a pin bump, or wire it
+# into a NON-gating daily cron. It shares the exact classification the
+# in-process validator uses (`provenance::classify_libvips_pin`), exercised in
+# `tests/libvips_upstream_check.rs`.
+#
+# Usage:  ./tools/check-libvips-pin.sh
+# Needs:  curl, jq (the same tools the Docker path and fixtures already use).
+# Exit:   0 up-to-date · 1 newer release or digest mismatch · 2 could not check.
+# ---------------------------------------------------------------------------
+
+API="https://api.github.com/repos/libvips/libvips/releases?per_page=20"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROVENANCE="${SCRIPT_DIR}/../src/provenance.rs"
+
+for tool in curl jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "Error: '${tool}' is required but not installed." >&2
+        exit 2
+    fi
+done
+
+# Read the pin from the single source of truth (provenance.rs) so this check
+# and the recorded constants can never drift apart. Tolerates the value sitting
+# on the next line (rustfmt wraps the long SHA-256 literal).
+extract_const() {
+    tr '\n' ' ' <"$PROVENANCE" \
+        | grep -oE "pub const $1: &str =[^\"]*\"[0-9A-Za-z.]+\"" \
+        | grep -oE '"[0-9A-Za-z.]+"' \
+        | tr -d '"' \
+        | head -1
+}
+
+PINNED_LIBVIPS_VERSION="$(extract_const PINNED_LIBVIPS_VERSION)"
+PINNED_LIBVIPS_SHA256="$(extract_const PINNED_LIBVIPS_SHA256)"
+
+if [ -z "$PINNED_LIBVIPS_VERSION" ] || [ -z "$PINNED_LIBVIPS_SHA256" ]; then
+    echo "Error: could not read the pin from ${PROVENANCE}." >&2
+    exit 2
+fi
+
+echo "Pinned libvips: ${PINNED_LIBVIPS_VERSION} (sha256 ${PINNED_LIBVIPS_SHA256})"
+echo "Querying ${API} ..."
+
+RELEASES="$(curl -fsSL -H 'Accept: application/vnd.github+json' "$API")" || {
+    echo "Error: could not fetch the upstream releases feed." >&2
+    exit 2
+}
+
+# Latest stable release (skip drafts and pre-releases), tag stripped of `v` and
+# ordered by numeric (major, minor, patch).
+LATEST="$(printf '%s' "$RELEASES" \
+    | jq -r '[.[] | select(.draft == false and .prerelease == false)
+                  | .tag_name | ltrimstr("v")]
+             | sort_by(split(".") | map(tonumber? // 0)) | last // empty')"
+
+# Upstream digest of the pinned tarball, if the feed still carries it.
+UPSTREAM_SHA="$(printf '%s' "$RELEASES" \
+    | jq -r --arg v "$PINNED_LIBVIPS_VERSION" \
+        '.[] | select((.tag_name | ltrimstr("v")) == $v)
+             | .assets[]? | select(.name == "vips-\($v).tar.xz")
+             | .digest | ltrimstr("sha256:")' \
+    | head -1)"
+
+status=0
+
+# Integrity first: a re-cut pinned tarball outranks a mere newer release.
+if [ -n "$UPSTREAM_SHA" ] && [ "$UPSTREAM_SHA" != "$PINNED_LIBVIPS_SHA256" ]; then
+    echo "MISMATCH: upstream vips-${PINNED_LIBVIPS_VERSION}.tar.xz is now ${UPSTREAM_SHA}," >&2
+    echo "          but the pin records ${PINNED_LIBVIPS_SHA256}." >&2
+    status=1
+elif [ -z "$UPSTREAM_SHA" ]; then
+    echo "WARNING: vips-${PINNED_LIBVIPS_VERSION}.tar.xz not found in the feed; digest unverified." >&2
+fi
+
+# Then freshness: a strictly newer latest stable is a bump target.
+if [ -n "$LATEST" ] && [ "$LATEST" != "$PINNED_LIBVIPS_VERSION" ]; then
+    newest="$(printf '%s\n%s\n' "$PINNED_LIBVIPS_VERSION" "$LATEST" \
+        | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)"
+    if [ "$newest" = "$LATEST" ]; then
+        echo "NEWER RELEASE: upstream latest stable is ${LATEST} (pinned ${PINNED_LIBVIPS_VERSION})."
+        status=1
+    fi
+fi
+
+if [ "$status" -eq 0 ]; then
+    echo "OK: pinned libvips ${PINNED_LIBVIPS_VERSION} is the latest stable and its SHA-256 matches upstream."
+fi
+exit "$status"


### PR DESCRIPTION
Resolves **#35** and **#36** (follow-ups from #24). #35: digest-pinned both base images (`debian@sha256`, `rust@sha256`) + snapshot.debian.org apt pinning on both stages, freezing libpng (the DeepZoom PNG hot path) and the codec/meson toolchain instead of floating them. #36: on-demand libvips-pin validator — `provenance::classify_libvips_pin` (single source of truth) + a `check-libvips-pin` binary + `tools/check-libvips-pin.sh` that shells out to it (no jq/bash reimplementation) + an `#[ignore]` live test. No CI cron added (repo policy).

TDD: RED tests → impl. 4-expert review applied (dual-classifier divergence fixed by the shared Rust binary). Clean rebase onto #38/charts. Local gate green.

Closes #35
Closes #36