### PR TITLE
Budget hardening: fail-soft engine runs + budget-coupling reconcile (#46, #47)

### DIFF
--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -118,7 +118,7 @@ fn generate_flamegraph(stacks: &[String], output_path: &Path, title: &str) {
     flamegraph::from_reader(&mut opts, reader.as_bytes(), writer).expect("generate flamegraph");
 }
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let report_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("report");
     fs::create_dir_all(&report_dir).unwrap();
 
@@ -129,8 +129,9 @@ fn main() {
     // Size the streaming/mapreduce budget to admit the worst-case tile-aligned
     // strip at this 4096-wide canvas: a flat 1 MB trips `BudgetPolicy::Error`'s
     // `BudgetExceeded` up front (worst-case strip = 4096·512·3 = 6.29 MB) and
-    // `.run().unwrap()` would panic — the exact failure mode issue #38 fixes.
-    // RGB8 gradient, so bpp = 3; shared with the report/scalability paths.
+    // the engine `.run()?` below would surface it as an error — the exact
+    // failure mode issue #38 sizes around. RGB8 gradient, so bpp = 3; shared
+    // with the report/scalability paths.
     let budget = streaming_budget_for(1_000_000, plan.canvas_width, TILE_SIZE, 3);
 
     println!("Image: {WIDTH}x{HEIGHT}, tile_size={TILE_SIZE}");
@@ -151,8 +152,7 @@ fn main() {
             .with_engine(EngineKind::Monolithic)
             .with_config(EngineConfig::default())
             .with_observer_arc(observer.clone())
-            .run()
-            .unwrap();
+            .run()?;
         let elapsed = start.elapsed();
 
         println!(
@@ -185,8 +185,7 @@ fn main() {
             .with_memory_budget(budget)
             .with_budget_policy(BudgetPolicy::Error)
             .with_observer_arc(observer.clone())
-            .run()
-            .unwrap();
+            .run()?;
         let elapsed = start.elapsed();
 
         let strip_count = observer
@@ -226,8 +225,7 @@ fn main() {
             .with_memory_budget(budget)
             .with_budget_policy(BudgetPolicy::Error)
             .with_observer_arc(observer.clone())
-            .run()
-            .unwrap();
+            .run()?;
         let elapsed = start.elapsed();
 
         let events = observer.events();
@@ -261,4 +259,6 @@ fn main() {
 
     println!();
     println!("Flame graphs written to {}", report_dir.display());
+
+    Ok(())
 }

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -78,28 +78,13 @@ impl Engine {
     }
 }
 
-/// Degrade a fail-soft streaming / mapreduce cell to a skipped row: on a genuine
-/// engine fault (the strict `BudgetPolicy::Error` these engines run under, a
-/// sink IO error, the plan/source dimension guard, …) record no metrics and
-/// warn, so the parent driver drops just that cell instead of the child
-/// panicking and taking the whole engine series down with it (issue #46).
-fn warn_on_skip(label: &str, res: Result<RunMetrics, libviprs::EngineError>) -> Option<RunMetrics> {
-    match res {
-        Ok(m) => Some(m),
-        Err(e) => {
-            eprintln!("cell {label} failed, skipping (issue #46): {e}");
-            None
-        }
-    }
-}
-
 /// Run exactly one cell in *this* process and return its metrics.
 ///
 /// This is the child body behind `--single`. Each engine is exercised once
 /// (single shot); the parent handles warm-up, repetition, and aggregation.
-/// A streaming / mapreduce engine fault degrades to `None` (a skipped cell)
-/// rather than panicking, so one unmeasurable cell never aborts the report
-/// (issue #46).
+/// Any engine fault degrades to `None` (a skipped cell) via the shared
+/// [`skip_on_engine_fault`](crate::skip_on_engine_fault) rather than panicking,
+/// so one unmeasurable cell never aborts the report (issue #46).
 pub fn run_single_cell(spec: CellSpec) -> Option<RunMetrics> {
     use libviprs::{Layout, PyramidPlanner};
 
@@ -141,13 +126,11 @@ pub fn run_single_cell(spec: CellSpec) -> Option<RunMetrics> {
                     .ok()?;
             let plan = planner.plan();
             match other {
-                Engine::Monolithic => Some(crate::bench_monolithic(
-                    &src,
-                    &plan,
-                    spec.concurrency,
+                Engine::Monolithic => crate::skip_on_engine_fault(
                     &label,
-                )),
-                Engine::Streaming => warn_on_skip(
+                    crate::bench_monolithic(&src, &plan, spec.concurrency, &label),
+                ),
+                Engine::Streaming => crate::skip_on_engine_fault(
                     &label,
                     crate::bench_streaming(
                         &src,
@@ -157,7 +140,7 @@ pub fn run_single_cell(spec: CellSpec) -> Option<RunMetrics> {
                         &label,
                     ),
                 ),
-                Engine::MapReduce => warn_on_skip(
+                Engine::MapReduce => crate::skip_on_engine_fault(
                     &label,
                     crate::bench_mapreduce(
                         &src,

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -78,10 +78,28 @@ impl Engine {
     }
 }
 
+/// Degrade a fail-soft streaming / mapreduce cell to a skipped row: on a genuine
+/// engine fault (the strict `BudgetPolicy::Error` these engines run under, a
+/// sink IO error, the plan/source dimension guard, …) record no metrics and
+/// warn, so the parent driver drops just that cell instead of the child
+/// panicking and taking the whole engine series down with it (issue #46).
+fn warn_on_skip(label: &str, res: Result<RunMetrics, libviprs::EngineError>) -> Option<RunMetrics> {
+    match res {
+        Ok(m) => Some(m),
+        Err(e) => {
+            eprintln!("cell {label} failed, skipping (issue #46): {e}");
+            None
+        }
+    }
+}
+
 /// Run exactly one cell in *this* process and return its metrics.
 ///
 /// This is the child body behind `--single`. Each engine is exercised once
 /// (single shot); the parent handles warm-up, repetition, and aggregation.
+/// A streaming / mapreduce engine fault degrades to `None` (a skipped cell)
+/// rather than panicking, so one unmeasurable cell never aborts the report
+/// (issue #46).
 pub fn run_single_cell(spec: CellSpec) -> Option<RunMetrics> {
     use libviprs::{Layout, PyramidPlanner};
 
@@ -122,18 +140,35 @@ pub fn run_single_cell(spec: CellSpec) -> Option<RunMetrics> {
                 PyramidPlanner::new(spec.width, spec.height, spec.tile_size, 0, Layout::DeepZoom)
                     .ok()?;
             let plan = planner.plan();
-            Some(match other {
-                Engine::Monolithic => {
-                    crate::bench_monolithic(&src, &plan, spec.concurrency, &label)
-                }
-                Engine::Streaming => {
-                    crate::bench_streaming(&src, &plan, spec.concurrency, spec.budget_bytes, &label)
-                }
-                Engine::MapReduce => {
-                    crate::bench_mapreduce(&src, &plan, spec.concurrency, spec.budget_bytes, &label)
-                }
+            match other {
+                Engine::Monolithic => Some(crate::bench_monolithic(
+                    &src,
+                    &plan,
+                    spec.concurrency,
+                    &label,
+                )),
+                Engine::Streaming => warn_on_skip(
+                    &label,
+                    crate::bench_streaming(
+                        &src,
+                        &plan,
+                        spec.concurrency,
+                        spec.budget_bytes,
+                        &label,
+                    ),
+                ),
+                Engine::MapReduce => warn_on_skip(
+                    &label,
+                    crate::bench_mapreduce(
+                        &src,
+                        &plan,
+                        spec.concurrency,
+                        spec.budget_bytes,
+                        &label,
+                    ),
+                ),
                 Engine::Libvips => unreachable!(),
-            })
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,18 +363,77 @@ pub fn gradient_raster(w: u32, h: u32) -> Raster {
     Raster::new(w, h, PixelFormat::Rgb8, data).unwrap()
 }
 
+/// A libviprs engine's temp tile-output directory that reclaims itself on drop.
+///
+/// Leak-freedom (issue #46) is enforced by the type, not by hand: every
+/// `bench_*` path that fails after creating its output dir — whether the engine
+/// returns `Err` (surfaced via `?`), the function returns early, OR the engine
+/// unwinds — drops this guard, and the drop removes the directory. This
+/// subsumes the earlier per-function `remove_dir_all` hand-placed just before
+/// each `?`, which covered only the returned-`Err` channel and would have leaked
+/// on an unwind.
+struct TempOutDir(std::path::PathBuf);
+
+impl TempOutDir {
+    /// The directory path. Engines root their `pyramid/` tiles under it, and the
+    /// success path counts those tiles (via [`per_level_png_tiles`]) while the
+    /// guard is still alive.
+    fn path(&self) -> &std::path::Path {
+        &self.0
+    }
+}
+
+impl Drop for TempOutDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
 /// Create a fresh, unique temp directory for a libviprs engine's on-disk tile
-/// output. Both the libviprs engines and libvips `dzsave` write their tiles as
-/// real files under `TMPDIR/libviprs-bench/…`, so neither side gets an in-RAM
-/// sink advantage (issue #153). The directory is removed by the caller once
-/// the tiles have been counted.
-fn fs_sink_dir(label: &str) -> std::path::PathBuf {
+/// output, returned as a self-reclaiming [`TempOutDir`] guard. Both the libviprs
+/// engines and libvips `dzsave` write their tiles as real files under
+/// `TMPDIR/libviprs-bench/…`, so neither side gets an in-RAM sink advantage
+/// (issue #153). The directory is removed when the returned guard drops.
+fn fs_sink_dir(label: &str) -> TempOutDir {
     let dir = std::env::temp_dir()
         .join("libviprs-bench")
         .join(format!("engine_{}_{label}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
+    // A writable `$TMPDIR` is a precondition for running any benchmark at all,
+    // so this is an accepted environmental panic — the right loud failure if the
+    // temp root is unwritable. The label is unique per cell and cells run
+    // serially, so there is no same-process collision to guard against.
     std::fs::create_dir_all(&dir).unwrap();
-    dir
+    TempOutDir(dir)
+}
+
+/// One voice for every fail-soft "engine fault → skip this cell/point" warning
+/// across the drivers — the child harness, the in-process [`comparison_suite`],
+/// and the `scalability` sweep — so the sites can't drift in wording. `context`
+/// names the engine and the cell/point (e.g. `"cell 4096x4096_c0_stream"` or
+/// `"scalability mapreduce 4096x4096"`). The issue reference stays in the code
+/// comments, not in this operator-facing line (issue #46 review).
+pub fn warn_engine_skip(context: &str, err: &libviprs::EngineError) {
+    eprintln!("{context} failed, skipping: {err}");
+}
+
+/// Degrade a fail-soft engine cell to a skipped row: on a genuine engine fault
+/// (the strict `BudgetPolicy::Error` the streaming / mapreduce engines run
+/// under, a sink IO error, the entry-time plan/source dimension guard, …) record
+/// no metrics and warn via [`warn_engine_skip`], so a driver drops just that one
+/// cell instead of aborting the whole engine series (issue #46). Shared by the
+/// child harness ([`harness::run_single_cell`]) and [`comparison_suite`].
+pub(crate) fn skip_on_engine_fault(
+    label: &str,
+    res: Result<RunMetrics, libviprs::EngineError>,
+) -> Option<RunMetrics> {
+    match res {
+        Ok(m) => Some(m),
+        Err(e) => {
+            warn_engine_skip(&format!("cell {label}"), &e);
+            None
+        }
+    }
 }
 
 /// Build the on-disk PNG sink used by every libviprs engine, rooted under a
@@ -384,31 +443,41 @@ fn engine_fs_sink(out_dir: &std::path::Path, plan: &PyramidPlan) -> FsSink {
     FsSink::new(out_dir.join("pyramid"), plan.clone()).with_format(BENCH_TILE_FORMAT)
 }
 
-/// Run the monolithic engine and collect metrics.
+/// Run the monolithic engine and collect metrics, or return the engine error.
+///
+/// Symmetric with [`bench_streaming`] / [`bench_mapreduce`]: returns `Err`
+/// (propagating the engine's [`EngineError`](libviprs::EngineError) via `?`)
+/// rather than panicking on an engine fault. The monolithic engine has no
+/// budget policy, but it can still fail on a sink IO error or the entry-time
+/// plan/source dimension guard, so hardening it symmetrically means one
+/// unmeasurable cell degrades to a skipped row instead of aborting the whole
+/// report/sweep, and its self-reclaiming [`TempOutDir`] never leaks a directory
+/// under `$TMPDIR` (issue #46).
 pub fn bench_monolithic(
     src: &Raster,
     plan: &PyramidPlan,
     concurrency: usize,
     label: &str,
-) -> RunMetrics {
+) -> Result<RunMetrics, libviprs::EngineError> {
     let out_dir = fs_sink_dir(label);
-    let sink = engine_fs_sink(&out_dir, plan);
+    let sink = engine_fs_sink(out_dir.path(), plan);
     let observer = Arc::new(CollectingObserver::new());
     let config = EngineConfig::default().with_concurrency(concurrency);
 
     let start = Instant::now();
-    let result = EngineBuilder::new(src, plan.clone(), &sink)
+    let run_result = EngineBuilder::new(src, plan.clone(), &sink)
         .with_engine(EngineKind::Monolithic)
         .with_config(config)
         .with_observer_arc(observer.clone())
-        .run()
-        .unwrap();
+        .run();
     let wall_time = start.elapsed();
     let peak_rss_bytes = get_peak_rss();
-    let per_level_tiles = per_level_png_tiles(&out_dir.join("pyramid"));
-    let _ = std::fs::remove_dir_all(&out_dir);
+    // On a fault `?` returns here and `out_dir` drops, reclaiming the temp dir;
+    // the success-path tile count below runs while the guard is still alive.
+    let result = run_result?;
+    let per_level_tiles = per_level_png_tiles(&out_dir.path().join("pyramid"));
 
-    RunMetrics {
+    Ok(RunMetrics {
         label: label.to_string(),
         width: src.width(),
         height: src.height(),
@@ -428,7 +497,7 @@ pub fn bench_monolithic(
         inflight_strips: 0,
         concurrency,
         memory_budget_bytes: 0,
-    }
+    })
 }
 
 /// Size a streaming / mapreduce memory budget so the worst-case tile-aligned
@@ -466,25 +535,31 @@ pub fn bench_monolithic(
 /// [`PyramidPlan`] reaches magnitudes that would overflow (the planner's
 /// `checked_canvas_bounds` rejects them), so the saturation is purely defensive.
 ///
-/// **On the duplicated admission formula (issue #47).** This helper re-derives
-/// the streaming / mapreduce engines' pre-flight invariant
-/// (`canvas_width × 2·tile_size × bpp`), which the core does not expose as a
-/// public primitive: it exposes the *forward*
-/// [`compute_strip_height`](libviprs::compute_strip_height) and the
-/// full-working-set [`estimate_streaming_memory`](libviprs::estimate_streaming_memory),
-/// but NOT the *inverse* — the minimum budget that survives pre-flight.
-/// Adopting a core primitive was evaluated and declined as out of proportion to
-/// the coupling: it would either change the sized budget's value (the
-/// full-working-set estimate is a different, strictly larger quantity, which
-/// would also refund the lower levels this benchmark deliberately leaves
-/// unfunded) or require a new core API AND recoupling this intentionally *raw*
-/// `(canvas_width, tile_size, bpp)` signature to a `&PyramidPlan` — a signature
-/// the plan-less call sites (the `scalability` chart annotations) and the
-/// saturating-overflow guard rely on and no real plan could exercise. Instead
-/// the coupling is pinned to the engines' ACTUAL admission behaviour by a test
-/// (`tests/budget_hardening.rs::streaming_budget_min_strip_agrees_with_core_preflight`):
-/// the real engine must reject one byte below this minimum and admit at it, so
-/// if the core ever changes its admission rule the pin goes red.
+/// **On the duplicated admission formula (issue #47).** The un-doubled minimum
+/// this helper computes (`canvas_width × 2·tile_size × bpp`) is *exactly* the
+/// streaming / mapreduce engines' pre-flight `worst_case_strip_bytes` — the
+/// quantity each engine gates admission on before `BudgetExceeded`. The core
+/// computes it inline and identically in BOTH engines' gates
+/// (`streaming::worst_case_strip_bytes` at the streaming pre-flight and its
+/// twin in `streaming_mapreduce`) but does **not** expose it as a public
+/// function, so there is no core primitive to adopt today.
+///
+/// Adopting one was declined for this bench as out of proportion to the
+/// coupling — but NOT because it would change the sized value (it would not: a
+/// core accessor returning `worst_case_strip_bytes` would leave this helper's
+/// `floor.max(2×)` policy, and thus the sized budget, byte-for-byte unchanged).
+/// The real reasons are narrower: (1) exposing it is a change to the core
+/// crate, out of scope for a bench-only PR; and (2) the natural core signature
+/// is `(&PyramidPlan, PixelFormat)`, whereas this helper is deliberately *raw*
+/// `(canvas_width, tile_size, bpp)` so the plan-less call sites (the
+/// `scalability` chart annotations) and the saturating-overflow guard can use
+/// it — adopting a plan-based core fn would force recoupling to a `&PyramidPlan`
+/// no real plan could exercise. Instead the coupling is pinned to the engines'
+/// ACTUAL admission behaviour by a test
+/// (`tests/budget_hardening.rs::streaming_budget_min_strip_agrees_with_core_preflight`),
+/// which drives BOTH engines: each must reject one byte below this minimum (with
+/// `BudgetExceeded` specifically) and admit at it — so a drift in EITHER of the
+/// core's two independent gate copies turns the pin red.
 #[must_use]
 pub fn streaming_budget_for(floor: u64, canvas_width: u32, tile_size: u32, bpp: u32) -> u64 {
     let min_strip_bytes = (canvas_width as u64)
@@ -497,33 +572,46 @@ pub fn streaming_budget_for(floor: u64, canvas_width: u32, tile_size: u32, bpp: 
 ///
 /// Returns `Err` — propagating the engine's own
 /// [`EngineError`](libviprs::EngineError) via `?` — rather than panicking when
-/// the run fails for a non-budget reason (a sink IO error, a source error, or
-/// the entry-time plan/source dimension guard), so a single unmeasurable cell
-/// degrades to a skipped row instead of aborting the whole report/sweep (issue
-/// #46). The budget itself is sized up per canvas by [`streaming_budget_for`]
-/// so the strict [`BudgetPolicy::Error`] never trips on a large canvas (issue
-/// #38). The temp output dir is reclaimed on EVERY exit — including the error
-/// path — mirroring [`bench_streaming_pdf`], so a post-creation fault never
-/// leaks a directory under `$TMPDIR`.
+/// the run fails, so a single unmeasurable cell degrades to a skipped row
+/// instead of aborting the whole report/sweep (issue #46). The temp output dir
+/// is a self-reclaiming [`TempOutDir`], so a post-creation fault — returned OR
+/// unwound — never leaks a directory under `$TMPDIR`.
+///
+/// `budget_floor_bytes` is a *floor*, not the effective budget: it is sized up
+/// per canvas by [`streaming_budget_for`] so the strict [`BudgetPolicy::Error`]
+/// never trips on a large canvas (issue #38), and that sized value — not the
+/// floor — is what the engine runs with and what
+/// [`RunMetrics::memory_budget_bytes`] reports.
+///
+/// Every returned `EngineError` variant is handled the same by the drivers —
+/// logged and skipped — unlike the PDF sibling [`bench_streaming_pdf`], which
+/// splits an environmental skip from a must-surface regression. That asymmetry
+/// is deliberate: in the real gradient drivers the plan is always built from the
+/// source's own dimensions (so `PlanSourceMismatch` is unreachable) and the
+/// budget is pre-sized to clear pre-flight (so `BudgetExceeded` cannot trip),
+/// leaving only genuinely environmental faults (a sink IO error) that are
+/// legitimately skippable — so, unlike the PDF path, there is no distinct
+/// always-skip case to separate out (issue #22 review, issue #46).
 pub fn bench_streaming(
     src: &Raster,
     plan: &PyramidPlan,
     concurrency: usize,
-    memory_budget_bytes: u64,
+    budget_floor_bytes: u64,
     label: &str,
 ) -> Result<RunMetrics, libviprs::EngineError> {
-    // Size the budget to admit the worst-case tile-aligned strip so the strict
-    // `BudgetPolicy::Error` never trips on a large canvas; the flat report
-    // budget alone starves every image from 1024 px up (issue #38). Size from
-    // `plan.canvas_width` — the exact width the engine's pre-flight gates on.
+    // Size the budget UP from the floor to admit the worst-case tile-aligned
+    // strip so the strict `BudgetPolicy::Error` never trips on a large canvas;
+    // the flat report floor alone starves every image from 1024 px up (issue
+    // #38). Size from `plan.canvas_width` — the exact width the engine's
+    // pre-flight gates on.
     let budget = streaming_budget_for(
-        memory_budget_bytes,
+        budget_floor_bytes,
         plan.canvas_width,
         plan.tile_size,
         src.format().bytes_per_pixel() as u32,
     );
     let out_dir = fs_sink_dir(label);
-    let sink = engine_fs_sink(&out_dir, plan);
+    let sink = engine_fs_sink(out_dir.path(), plan);
     let observer = Arc::new(CollectingObserver::new());
     let engine_config = EngineConfig::default().with_concurrency(concurrency);
     let strip_src = RasterStripSource::new(src);
@@ -537,13 +625,10 @@ pub fn bench_streaming(
         .run();
     let wall_time = start.elapsed();
     let peak_rss_bytes = get_peak_rss();
-    // Reclaim the temp dir on EVERY exit — including the error path below — so a
-    // post-creation engine failure never leaks a directory under $TMPDIR (issue
-    // #46, mirroring `bench_streaming_pdf`). Walking a partial/empty dir here is
-    // harmless; the value is only consumed on the success path.
-    let per_level_tiles = per_level_png_tiles(&out_dir.join("pyramid"));
-    let _ = std::fs::remove_dir_all(&out_dir);
+    // On a fault `?` returns here and `out_dir` drops, reclaiming the temp dir;
+    // the success-path tile count below runs while the guard is still alive.
     let result = run_result?;
+    let per_level_tiles = per_level_png_tiles(&out_dir.path().join("pyramid"));
 
     let strips = observer
         .events()
@@ -578,30 +663,33 @@ pub fn bench_streaming(
 ///
 /// The MapReduce counterpart to [`bench_streaming`]: returns `Err` (propagating
 /// the engine's [`EngineError`](libviprs::EngineError) via `?`) rather than
-/// panicking on a non-budget engine fault, and reclaims the temp output dir on
-/// every exit — including the error path — so a failed cell degrades to a
-/// skipped row and never leaks a directory under `$TMPDIR` (issue #46).
+/// panicking on an engine fault, and its self-reclaiming [`TempOutDir`] never
+/// leaks a directory under `$TMPDIR` on any exit — returned or unwound — so a
+/// failed cell degrades to a skipped row (issue #46). Like [`bench_streaming`],
+/// `budget_floor_bytes` is a *floor* that [`streaming_budget_for`] sizes up per
+/// canvas; the sized value is what the engine runs with (and what the
+/// strip-height / in-flight accounting below is computed against).
 pub fn bench_mapreduce(
     src: &Raster,
     plan: &PyramidPlan,
     tile_concurrency: usize,
-    memory_budget_bytes: u64,
+    budget_floor_bytes: u64,
     label: &str,
 ) -> Result<RunMetrics, libviprs::EngineError> {
-    // Size the budget to admit the worst-case tile-aligned strip so the strict
-    // `BudgetPolicy::Error` never trips on a large canvas; the flat report
-    // budget alone starves every image from 1024 px up (issue #38). Size from
-    // `plan.canvas_width` — the exact width the engine's pre-flight gates on.
-    // The sized budget is what the engine runs with, so the strip-height and
-    // in-flight accounting below is computed against it too.
+    // Size the budget UP from the floor to admit the worst-case tile-aligned
+    // strip so the strict `BudgetPolicy::Error` never trips on a large canvas;
+    // the flat report floor alone starves every image from 1024 px up (issue
+    // #38). Size from `plan.canvas_width` — the exact width the engine's
+    // pre-flight gates on. The sized budget is what the engine runs with, so the
+    // strip-height and in-flight accounting below is computed against it too.
     let budget = streaming_budget_for(
-        memory_budget_bytes,
+        budget_floor_bytes,
         plan.canvas_width,
         plan.tile_size,
         src.format().bytes_per_pixel() as u32,
     );
     let out_dir = fs_sink_dir(label);
-    let sink = engine_fs_sink(&out_dir, plan);
+    let sink = engine_fs_sink(out_dir.path(), plan);
     let observer = Arc::new(CollectingObserver::new());
     let buffer_size = 64usize;
     let engine_config = EngineConfig::default()
@@ -619,13 +707,10 @@ pub fn bench_mapreduce(
         .run();
     let wall_time = start.elapsed();
     let peak_rss_bytes = get_peak_rss();
-    // Reclaim the temp dir on EVERY exit — including the error path below — so a
-    // post-creation engine failure never leaks a directory under $TMPDIR (issue
-    // #46, mirroring `bench_streaming_pdf`). Walking a partial/empty dir here is
-    // harmless; the value is only consumed on the success path.
-    let per_level_tiles = per_level_png_tiles(&out_dir.join("pyramid"));
-    let _ = std::fs::remove_dir_all(&out_dir);
+    // On a fault `?` returns here and `out_dir` drops, reclaiming the temp dir;
+    // the success-path tile count below runs while the guard is still alive.
     let result = run_result?;
+    let per_level_tiles = per_level_png_tiles(&out_dir.path().join("pyramid"));
 
     let events = observer.events();
     let strips = events
@@ -756,12 +841,17 @@ impl std::error::Error for PdfBenchError {
 /// [`BudgetPolicy::Error`] — pdfium's 4-bpp strips are wider than the 3-bpp
 /// gradient at the same width.
 ///
-/// Returns a typed [`PdfBenchError`] (rather than panicking like the raster
-/// [`bench_streaming`]) so a driver can tell the ONE legitimately-skippable
-/// case — [`PdfBenchError::SourceUnavailable`], e.g. a missing or
-/// ABI-mismatched `libpdfium` — apart from a genuine planner/engine regression
-/// ([`PdfBenchError::Plan`] / [`PdfBenchError::Engine`]) that it must surface
-/// rather than silently drop from the deliverable (issue #22 review).
+/// Returns a *typed* [`PdfBenchError`] — unlike the raster [`bench_streaming`]'s
+/// single opaque [`EngineError`](libviprs::EngineError) — so a driver can tell
+/// the ONE legitimately-skippable case — [`PdfBenchError::SourceUnavailable`],
+/// e.g. a missing or ABI-mismatched `libpdfium` — apart from a genuine
+/// planner/engine regression ([`PdfBenchError::Plan`] / [`PdfBenchError::Engine`])
+/// that it must surface rather than silently drop from the deliverable. The
+/// raster path needs no such split because its only reachable fault in the real
+/// drivers is environmental (see [`bench_streaming`]) (issue #22 review).
+///
+/// Like the raster paths, `budget_floor_bytes` is a *floor* that
+/// [`streaming_budget_for`] sizes up per canvas.
 #[cfg(feature = "pdfium")]
 #[allow(clippy::too_many_arguments)]
 pub fn bench_streaming_pdf(
@@ -770,7 +860,7 @@ pub fn bench_streaming_pdf(
     dpi: u32,
     tile_size: u32,
     concurrency: usize,
-    memory_budget_bytes: u64,
+    budget_floor_bytes: u64,
     label: &str,
 ) -> Result<RunMetrics, PdfBenchError> {
     use libviprs::{PdfiumStripSource, StripSource};
@@ -790,14 +880,14 @@ pub fn bench_streaming_pdf(
     // `bench_mapreduce` path via `streaming_budget_for` (saturating), sized from
     // `plan.canvas_width` — the width the engine's pre-flight gates on.
     let budget = streaming_budget_for(
-        memory_budget_bytes,
+        budget_floor_bytes,
         plan.canvas_width,
         plan.tile_size,
         source.format().bytes_per_pixel() as u32,
     );
 
     let out_dir = fs_sink_dir(label);
-    let sink = engine_fs_sink(&out_dir, &plan);
+    let sink = engine_fs_sink(out_dir.path(), &plan);
     let observer = Arc::new(CollectingObserver::new());
     let engine_config = EngineConfig::default().with_concurrency(concurrency);
 
@@ -811,13 +901,11 @@ pub fn bench_streaming_pdf(
         .run();
     let wall_time = start.elapsed();
     let peak_rss_bytes = get_peak_rss();
-    // Reclaim the temp dir on EVERY exit — including the error path below — so a
-    // post-creation engine failure never leaks a directory under $TMPDIR
-    // (issue #22 review). Walking a partial/empty dir here is harmless; the
-    // value is only consumed on the success path.
-    let per_level_tiles = per_level_png_tiles(&out_dir.join("pyramid"));
-    let _ = std::fs::remove_dir_all(&out_dir);
+    // On a fault `?` returns here and `out_dir` drops, reclaiming the temp dir
+    // (issue #22 review, issue #46); the success-path tile count below runs
+    // while the guard is still alive.
     let result = run_result.map_err(PdfBenchError::Engine)?;
+    let per_level_tiles = per_level_png_tiles(&out_dir.path().join("pyramid"));
 
     let strips = observer
         .events()
@@ -909,7 +997,7 @@ pub fn write_libviprs_pyramid(
     plan: &PyramidPlan,
     engine: EngineKind,
     concurrency: usize,
-    budget_bytes: u64,
+    budget_floor_bytes: u64,
     dir: &std::path::Path,
 ) -> std::io::Result<std::path::PathBuf> {
     std::fs::create_dir_all(dir)?;
@@ -927,7 +1015,7 @@ pub fn write_libviprs_pyramid(
     // review). The monolithic engine ignores the budget.
     if matches!(engine, EngineKind::Streaming | EngineKind::MapReduce) {
         let budget = streaming_budget_for(
-            budget_bytes,
+            budget_floor_bytes,
             plan.canvas_width,
             plan.tile_size,
             src.format().bytes_per_pixel() as u32,
@@ -1415,11 +1503,14 @@ pub fn per_level_png_tiles(tiles_dir: &std::path::Path) -> Vec<u64> {
 }
 
 /// Run all four engines across a matrix of image sizes and concurrency levels.
+///
+/// `streaming_budget_floor_bytes` is the streaming / mapreduce budget *floor*;
+/// each cell sizes it up per canvas via [`streaming_budget_for`] (issue #38).
 pub fn comparison_suite(
     sizes: &[(u32, u32)],
     concurrency_levels: &[usize],
     tile_size: u32,
-    streaming_budget_bytes: u64,
+    streaming_budget_floor_bytes: u64,
 ) -> Vec<RunMetrics> {
     let mut results = Vec::new();
 
@@ -1445,32 +1536,38 @@ pub fn comparison_suite(
         for &conc in concurrency_levels {
             let label = format!("{w}x{h}_c{conc}");
 
-            let mono = bench_monolithic(&src, &plan, conc, &format!("{label}_mono"));
-            results.push(mono);
-
-            // Fail-soft: a streaming / mapreduce engine fault degrades that one
-            // cell to a skipped (warned) row rather than aborting the whole
-            // sweep, mirroring the child-process driver (issue #46).
-            match bench_streaming(
-                &src,
-                &plan,
-                conc,
-                streaming_budget_bytes,
-                &format!("{label}_stream"),
+            // Fail-soft: an engine fault degrades that one cell to a skipped
+            // (warned) row rather than aborting the whole sweep, mirroring the
+            // child-process driver, and routed through the shared
+            // `skip_on_engine_fault` so every driver logs in one voice (#46).
+            let mono_label = format!("{label}_mono");
+            if let Some(mono) = skip_on_engine_fault(
+                &mono_label,
+                bench_monolithic(&src, &plan, conc, &mono_label),
             ) {
-                Ok(stream) => results.push(stream),
-                Err(e) => eprintln!("streaming cell {label} failed, skipping (issue #46): {e}"),
+                results.push(mono);
             }
 
-            match bench_mapreduce(
-                &src,
-                &plan,
-                conc,
-                streaming_budget_bytes,
-                &format!("{label}_mr"),
+            let stream_label = format!("{label}_stream");
+            if let Some(stream) = skip_on_engine_fault(
+                &stream_label,
+                bench_streaming(
+                    &src,
+                    &plan,
+                    conc,
+                    streaming_budget_floor_bytes,
+                    &stream_label,
+                ),
             ) {
-                Ok(mr) => results.push(mr),
-                Err(e) => eprintln!("mapreduce cell {label} failed, skipping (issue #46): {e}"),
+                results.push(stream);
+            }
+
+            let mr_label = format!("{label}_mr");
+            if let Some(mr) = skip_on_engine_fault(
+                &mr_label,
+                bench_mapreduce(&src, &plan, conc, streaming_budget_floor_bytes, &mr_label),
+            ) {
+                results.push(mr);
             }
 
             // libvips: prefer in-process FFI when available, fall back to CLI.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,6 +465,26 @@ pub fn bench_monolithic(
 /// Saturating arithmetic keeps the helper total and panic-free. No constructible
 /// [`PyramidPlan`] reaches magnitudes that would overflow (the planner's
 /// `checked_canvas_bounds` rejects them), so the saturation is purely defensive.
+///
+/// **On the duplicated admission formula (issue #47).** This helper re-derives
+/// the streaming / mapreduce engines' pre-flight invariant
+/// (`canvas_width × 2·tile_size × bpp`), which the core does not expose as a
+/// public primitive: it exposes the *forward*
+/// [`compute_strip_height`](libviprs::compute_strip_height) and the
+/// full-working-set [`estimate_streaming_memory`](libviprs::estimate_streaming_memory),
+/// but NOT the *inverse* — the minimum budget that survives pre-flight.
+/// Adopting a core primitive was evaluated and declined as out of proportion to
+/// the coupling: it would either change the sized budget's value (the
+/// full-working-set estimate is a different, strictly larger quantity, which
+/// would also refund the lower levels this benchmark deliberately leaves
+/// unfunded) or require a new core API AND recoupling this intentionally *raw*
+/// `(canvas_width, tile_size, bpp)` signature to a `&PyramidPlan` — a signature
+/// the plan-less call sites (the `scalability` chart annotations) and the
+/// saturating-overflow guard rely on and no real plan could exercise. Instead
+/// the coupling is pinned to the engines' ACTUAL admission behaviour by a test
+/// (`tests/budget_hardening.rs::streaming_budget_min_strip_agrees_with_core_preflight`):
+/// the real engine must reject one byte below this minimum and admit at it, so
+/// if the core ever changes its admission rule the pin goes red.
 #[must_use]
 pub fn streaming_budget_for(floor: u64, canvas_width: u32, tile_size: u32, bpp: u32) -> u64 {
     let min_strip_bytes = (canvas_width as u64)
@@ -473,14 +493,25 @@ pub fn streaming_budget_for(floor: u64, canvas_width: u32, tile_size: u32, bpp: 
     floor.max(min_strip_bytes.saturating_mul(2))
 }
 
-/// Run the streaming engine and collect metrics.
+/// Run the streaming engine and collect metrics, or return the engine error.
+///
+/// Returns `Err` — propagating the engine's own
+/// [`EngineError`](libviprs::EngineError) via `?` — rather than panicking when
+/// the run fails for a non-budget reason (a sink IO error, a source error, or
+/// the entry-time plan/source dimension guard), so a single unmeasurable cell
+/// degrades to a skipped row instead of aborting the whole report/sweep (issue
+/// #46). The budget itself is sized up per canvas by [`streaming_budget_for`]
+/// so the strict [`BudgetPolicy::Error`] never trips on a large canvas (issue
+/// #38). The temp output dir is reclaimed on EVERY exit — including the error
+/// path — mirroring [`bench_streaming_pdf`], so a post-creation fault never
+/// leaks a directory under `$TMPDIR`.
 pub fn bench_streaming(
     src: &Raster,
     plan: &PyramidPlan,
     concurrency: usize,
     memory_budget_bytes: u64,
     label: &str,
-) -> RunMetrics {
+) -> Result<RunMetrics, libviprs::EngineError> {
     // Size the budget to admit the worst-case tile-aligned strip so the strict
     // `BudgetPolicy::Error` never trips on a large canvas; the flat report
     // budget alone starves every image from 1024 px up (issue #38). Size from
@@ -497,18 +528,22 @@ pub fn bench_streaming(
     let engine_config = EngineConfig::default().with_concurrency(concurrency);
     let strip_src = RasterStripSource::new(src);
     let start = Instant::now();
-    let result = EngineBuilder::new(strip_src, plan.clone(), &sink)
+    let run_result = EngineBuilder::new(strip_src, plan.clone(), &sink)
         .with_engine(EngineKind::Streaming)
         .with_config(engine_config)
         .with_memory_budget(budget)
         .with_budget_policy(BudgetPolicy::Error)
         .with_observer_arc(observer.clone())
-        .run()
-        .unwrap();
+        .run();
     let wall_time = start.elapsed();
     let peak_rss_bytes = get_peak_rss();
+    // Reclaim the temp dir on EVERY exit — including the error path below — so a
+    // post-creation engine failure never leaks a directory under $TMPDIR (issue
+    // #46, mirroring `bench_streaming_pdf`). Walking a partial/empty dir here is
+    // harmless; the value is only consumed on the success path.
     let per_level_tiles = per_level_png_tiles(&out_dir.join("pyramid"));
     let _ = std::fs::remove_dir_all(&out_dir);
+    let result = run_result?;
 
     let strips = observer
         .events()
@@ -516,7 +551,7 @@ pub fn bench_streaming(
         .filter(|e| matches!(e, EngineEvent::StripRendered { .. }))
         .count() as u32;
 
-    RunMetrics {
+    Ok(RunMetrics {
         label: label.to_string(),
         width: src.width(),
         height: src.height(),
@@ -536,17 +571,23 @@ pub fn bench_streaming(
         inflight_strips: 0,
         concurrency,
         memory_budget_bytes: budget,
-    }
+    })
 }
 
-/// Run the MapReduce engine and collect metrics.
+/// Run the MapReduce engine and collect metrics, or return the engine error.
+///
+/// The MapReduce counterpart to [`bench_streaming`]: returns `Err` (propagating
+/// the engine's [`EngineError`](libviprs::EngineError) via `?`) rather than
+/// panicking on a non-budget engine fault, and reclaims the temp output dir on
+/// every exit — including the error path — so a failed cell degrades to a
+/// skipped row and never leaks a directory under `$TMPDIR` (issue #46).
 pub fn bench_mapreduce(
     src: &Raster,
     plan: &PyramidPlan,
     tile_concurrency: usize,
     memory_budget_bytes: u64,
     label: &str,
-) -> RunMetrics {
+) -> Result<RunMetrics, libviprs::EngineError> {
     // Size the budget to admit the worst-case tile-aligned strip so the strict
     // `BudgetPolicy::Error` never trips on a large canvas; the flat report
     // budget alone starves every image from 1024 px up (issue #38). Size from
@@ -569,18 +610,22 @@ pub fn bench_mapreduce(
         .with_blank_tile_strategy(libviprs::BlankTileStrategy::Emit);
     let strip_src = RasterStripSource::new(src);
     let start = Instant::now();
-    let result = EngineBuilder::new(strip_src, plan.clone(), &sink)
+    let run_result = EngineBuilder::new(strip_src, plan.clone(), &sink)
         .with_engine(EngineKind::MapReduce)
         .with_config(engine_config)
         .with_memory_budget(budget)
         .with_budget_policy(BudgetPolicy::Error)
         .with_observer_arc(observer.clone())
-        .run()
-        .unwrap();
+        .run();
     let wall_time = start.elapsed();
     let peak_rss_bytes = get_peak_rss();
+    // Reclaim the temp dir on EVERY exit — including the error path below — so a
+    // post-creation engine failure never leaks a directory under $TMPDIR (issue
+    // #46, mirroring `bench_streaming_pdf`). Walking a partial/empty dir here is
+    // harmless; the value is only consumed on the success path.
     let per_level_tiles = per_level_png_tiles(&out_dir.join("pyramid"));
     let _ = std::fs::remove_dir_all(&out_dir);
+    let result = run_result?;
 
     let events = observer.events();
     let strips = events
@@ -613,7 +658,7 @@ pub fn bench_mapreduce(
         budget,
     );
 
-    RunMetrics {
+    Ok(RunMetrics {
         label: label.to_string(),
         width: src.width(),
         height: src.height(),
@@ -633,7 +678,7 @@ pub fn bench_mapreduce(
         inflight_strips: inflight,
         concurrency: tile_concurrency,
         memory_budget_bytes: budget,
-    }
+    })
 }
 
 /// Failure modes of [`bench_streaming_pdf`], split so a benchmark driver can
@@ -1403,23 +1448,30 @@ pub fn comparison_suite(
             let mono = bench_monolithic(&src, &plan, conc, &format!("{label}_mono"));
             results.push(mono);
 
-            let stream = bench_streaming(
+            // Fail-soft: a streaming / mapreduce engine fault degrades that one
+            // cell to a skipped (warned) row rather than aborting the whole
+            // sweep, mirroring the child-process driver (issue #46).
+            match bench_streaming(
                 &src,
                 &plan,
                 conc,
                 streaming_budget_bytes,
                 &format!("{label}_stream"),
-            );
-            results.push(stream);
+            ) {
+                Ok(stream) => results.push(stream),
+                Err(e) => eprintln!("streaming cell {label} failed, skipping (issue #46): {e}"),
+            }
 
-            let mr = bench_mapreduce(
+            match bench_mapreduce(
                 &src,
                 &plan,
                 conc,
                 streaming_budget_bytes,
                 &format!("{label}_mr"),
-            );
-            results.push(mr);
+            ) {
+                Ok(mr) => results.push(mr),
+                Err(e) => eprintln!("mapreduce cell {label} failed, skipping (issue #46): {e}"),
+            }
 
             // libvips: prefer in-process FFI when available, fall back to CLI.
             // `vips_done` is only reassigned under the `libvips` feature.

--- a/src/scalability.rs
+++ b/src/scalability.rs
@@ -139,7 +139,12 @@ fn run_monolithic(src: &Raster, tile_size: u32, concurrency: usize) -> EngineRun
     }
 }
 
-fn run_streaming(src: &Raster, tile_size: u32, budget: u64, concurrency: usize) -> EngineRun {
+fn run_streaming(
+    src: &Raster,
+    tile_size: u32,
+    budget: u64,
+    concurrency: usize,
+) -> Option<EngineRun> {
     let planner =
         PyramidPlanner::new(src.width(), src.height(), tile_size, 0, Layout::DeepZoom).unwrap();
     let plan = planner.plan();
@@ -147,25 +152,43 @@ fn run_streaming(src: &Raster, tile_size: u32, budget: u64, concurrency: usize) 
     let sink = FsSink::new(out_dir.join("pyramid"), plan.clone()).with_format(TileFormat::Png);
     let strip_src = RasterStripSource::new(src);
     let start = Instant::now();
-    let result = EngineBuilder::new(strip_src, plan, &sink)
+    let run_result = EngineBuilder::new(strip_src, plan, &sink)
         .with_engine(EngineKind::Streaming)
         .with_config(EngineConfig::default().with_concurrency(concurrency))
         .with_memory_budget(budget)
         .with_budget_policy(BudgetPolicy::Error)
-        .run()
-        .unwrap();
+        .run();
     let dur = start.elapsed();
     let rss_bytes = process_peak_rss();
+    // Reclaim the temp dir on every exit — including the error path — so a
+    // genuine engine fault degrades this point to a skipped series instead of
+    // aborting the whole sweep and leaking a dir under $TMPDIR (issue #46).
     let _ = std::fs::remove_dir_all(&out_dir);
-    EngineRun {
+    let result = match run_result {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!(
+                "scalability streaming {}x{} failed, skipping (issue #46): {e}",
+                src.width(),
+                src.height()
+            );
+            return None;
+        }
+    };
+    Some(EngineRun {
         dur,
         tracked_bytes: result.peak_memory_bytes,
         rss_bytes,
         tiles: result.tiles_produced,
-    }
+    })
 }
 
-fn run_mapreduce(src: &Raster, tile_size: u32, budget: u64, concurrency: usize) -> EngineRun {
+fn run_mapreduce(
+    src: &Raster,
+    tile_size: u32,
+    budget: u64,
+    concurrency: usize,
+) -> Option<EngineRun> {
     let planner =
         PyramidPlanner::new(src.width(), src.height(), tile_size, 0, Layout::DeepZoom).unwrap();
     let plan = planner.plan();
@@ -173,22 +196,35 @@ fn run_mapreduce(src: &Raster, tile_size: u32, budget: u64, concurrency: usize) 
     let sink = FsSink::new(out_dir.join("pyramid"), plan.clone()).with_format(TileFormat::Png);
     let strip_src = RasterStripSource::new(src);
     let start = Instant::now();
-    let result = EngineBuilder::new(strip_src, plan, &sink)
+    let run_result = EngineBuilder::new(strip_src, plan, &sink)
         .with_engine(EngineKind::MapReduce)
         .with_config(EngineConfig::default().with_concurrency(concurrency))
         .with_memory_budget(budget)
         .with_budget_policy(BudgetPolicy::Error)
-        .run()
-        .unwrap();
+        .run();
     let dur = start.elapsed();
     let rss_bytes = process_peak_rss();
+    // Reclaim the temp dir on every exit — including the error path — so a
+    // genuine engine fault degrades this point to a skipped series instead of
+    // aborting the whole sweep and leaking a dir under $TMPDIR (issue #46).
     let _ = std::fs::remove_dir_all(&out_dir);
-    EngineRun {
+    let result = match run_result {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!(
+                "scalability mapreduce {}x{} failed, skipping (issue #46): {e}",
+                src.width(),
+                src.height()
+            );
+            return None;
+        }
+    };
+    Some(EngineRun {
         dur,
         tracked_bytes: result.peak_memory_bytes,
         rss_bytes,
         tiles: result.tiles_produced,
-    }
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -589,41 +625,48 @@ fn main() {
             // tile-aligned minimum strip always fits.
             let budget = streaming_budget_for(STREAMING_BUDGET_FLOOR, w, TILE_SIZE, 3);
 
-            // Streaming
-            let run = run_streaming(&src, TILE_SIZE, budget, conc);
-            print!(
-                "stream={:.0}ms/{:.1}MB(trk)  ",
-                run.dur.as_secs_f64() * 1000.0,
-                run.tracked_bytes as f64 / (1024.0 * 1024.0),
-            );
-            all_points.push(to_point(
-                w,
-                h,
-                "streaming",
-                conc,
-                run.dur,
-                run.tracked_bytes,
-                run.rss_bytes,
-                run.tiles,
-            ));
+            // Streaming — a genuine engine fault degrades to a skipped series
+            // (the reason is logged to stderr) rather than aborting the sweep.
+            if let Some(run) = run_streaming(&src, TILE_SIZE, budget, conc) {
+                print!(
+                    "stream={:.0}ms/{:.1}MB(trk)  ",
+                    run.dur.as_secs_f64() * 1000.0,
+                    run.tracked_bytes as f64 / (1024.0 * 1024.0),
+                );
+                all_points.push(to_point(
+                    w,
+                    h,
+                    "streaming",
+                    conc,
+                    run.dur,
+                    run.tracked_bytes,
+                    run.rss_bytes,
+                    run.tiles,
+                ));
+            } else {
+                print!("stream=skipped  ");
+            }
 
             // MapReduce
-            let run = run_mapreduce(&src, TILE_SIZE, budget, conc);
-            println!(
-                "mr={:.0}ms/{:.1}MB(trk)",
-                run.dur.as_secs_f64() * 1000.0,
-                run.tracked_bytes as f64 / (1024.0 * 1024.0),
-            );
-            all_points.push(to_point(
-                w,
-                h,
-                "mapreduce",
-                conc,
-                run.dur,
-                run.tracked_bytes,
-                run.rss_bytes,
-                run.tiles,
-            ));
+            if let Some(run) = run_mapreduce(&src, TILE_SIZE, budget, conc) {
+                println!(
+                    "mr={:.0}ms/{:.1}MB(trk)",
+                    run.dur.as_secs_f64() * 1000.0,
+                    run.tracked_bytes as f64 / (1024.0 * 1024.0),
+                );
+                all_points.push(to_point(
+                    w,
+                    h,
+                    "mapreduce",
+                    conc,
+                    run.dur,
+                    run.tracked_bytes,
+                    run.rss_bytes,
+                    run.tiles,
+                ));
+            } else {
+                println!("mr=skipped");
+            }
 
             // Real-content counterpart (issue #31): rasterize the committed PDF
             // fixture to ~this width via PdfiumStripSource (streaming) and

--- a/src/scalability.rs
+++ b/src/scalability.rs
@@ -116,27 +116,39 @@ fn sink_dir(label: &str) -> std::path::PathBuf {
     dir
 }
 
-fn run_monolithic(src: &Raster, tile_size: u32, concurrency: usize) -> EngineRun {
+fn run_monolithic(src: &Raster, tile_size: u32, concurrency: usize) -> Option<EngineRun> {
     let planner =
         PyramidPlanner::new(src.width(), src.height(), tile_size, 0, Layout::DeepZoom).unwrap();
     let plan = planner.plan();
     let out_dir = sink_dir("mono");
     let sink = FsSink::new(out_dir.join("pyramid"), plan.clone()).with_format(TileFormat::Png);
     let start = Instant::now();
-    let result = EngineBuilder::new(src, plan, &sink)
+    let run_result = EngineBuilder::new(src, plan, &sink)
         .with_engine(EngineKind::Monolithic)
         .with_config(EngineConfig::default().with_concurrency(concurrency))
-        .run()
-        .unwrap();
+        .run();
     let dur = start.elapsed();
     let rss_bytes = process_peak_rss();
+    // Reclaim the temp dir on every exit — including the error path — so a
+    // genuine engine fault degrades this point to a skipped series instead of
+    // aborting the whole sweep and leaking a dir under $TMPDIR (issue #46).
     let _ = std::fs::remove_dir_all(&out_dir);
-    EngineRun {
+    let result = match run_result {
+        Ok(r) => r,
+        Err(e) => {
+            libviprs_bench::warn_engine_skip(
+                &format!("scalability monolithic {}x{}", src.width(), src.height()),
+                &e,
+            );
+            return None;
+        }
+    };
+    Some(EngineRun {
         dur,
         tracked_bytes: result.peak_memory_bytes,
         rss_bytes,
         tiles: result.tiles_produced,
-    }
+    })
 }
 
 fn run_streaming(
@@ -167,10 +179,9 @@ fn run_streaming(
     let result = match run_result {
         Ok(r) => r,
         Err(e) => {
-            eprintln!(
-                "scalability streaming {}x{} failed, skipping (issue #46): {e}",
-                src.width(),
-                src.height()
+            libviprs_bench::warn_engine_skip(
+                &format!("scalability streaming {}x{}", src.width(), src.height()),
+                &e,
             );
             return None;
         }
@@ -211,10 +222,9 @@ fn run_mapreduce(
     let result = match run_result {
         Ok(r) => r,
         Err(e) => {
-            eprintln!(
-                "scalability mapreduce {}x{} failed, skipping (issue #46): {e}",
-                src.width(),
-                src.height()
+            libviprs_bench::warn_engine_skip(
+                &format!("scalability mapreduce {}x{}", src.width(), src.height()),
+                &e,
             );
             return None;
         }
@@ -603,23 +613,27 @@ fn main() {
                 let _ = fs::remove_file(&png_path);
             }
 
-            // Monolithic
-            let run = run_monolithic(&src, TILE_SIZE, conc);
-            print!(
-                "mono={:.0}ms/{:.1}MB(trk)  ",
-                run.dur.as_secs_f64() * 1000.0,
-                run.tracked_bytes as f64 / (1024.0 * 1024.0),
-            );
-            all_points.push(to_point(
-                w,
-                h,
-                "monolithic",
-                conc,
-                run.dur,
-                run.tracked_bytes,
-                run.rss_bytes,
-                run.tiles,
-            ));
+            // Monolithic — a genuine engine fault degrades to a skipped series
+            // (the reason is logged to stderr) rather than aborting the sweep.
+            if let Some(run) = run_monolithic(&src, TILE_SIZE, conc) {
+                print!(
+                    "mono={:.0}ms/{:.1}MB(trk)  ",
+                    run.dur.as_secs_f64() * 1000.0,
+                    run.tracked_bytes as f64 / (1024.0 * 1024.0),
+                );
+                all_points.push(to_point(
+                    w,
+                    h,
+                    "monolithic",
+                    conc,
+                    run.dur,
+                    run.tracked_bytes,
+                    run.rss_bytes,
+                    run.tiles,
+                ));
+            } else {
+                print!("mono=skipped  ");
+            }
 
             // Streaming + MapReduce share a budget chosen per-width so the
             // tile-aligned minimum strip always fits.

--- a/tests/budget_hardening.rs
+++ b/tests/budget_hardening.rs
@@ -25,9 +25,14 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::PathBuf;
 
-use libviprs::{Layout, PyramidPlan, PyramidPlanner, Raster};
+use libviprs::streaming::BudgetPolicy;
+use libviprs::{
+    EngineBuilder, EngineConfig, EngineKind, Layout, MemorySink, PyramidPlan, PyramidPlanner,
+    Raster, RasterStripSource,
+};
 use libviprs_bench::{
     BENCH_STREAMING_BUDGET, BENCH_TILE_SIZE, bench_mapreduce, bench_streaming, gradient_raster,
+    streaming_budget_for,
 };
 
 /// A 256×256 source paired with a plan built for 1024×1024. The engine's
@@ -96,5 +101,67 @@ fn mapreduce_cell_fault_does_not_panic_or_leak() {
         !out_dir.exists(),
         "bench_mapreduce leaked its temp output dir {} on the error path (issue #46)",
         out_dir.display()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #47: the re-derived budget-admission formula, pinned to core reality.
+// ---------------------------------------------------------------------------
+
+/// Whether the REAL streaming engine admits a run at `budget` — the observable
+/// image of the core's up-front pre-flight gate. Uses an in-memory sink so the
+/// probe touches no filesystem.
+fn streaming_admits(plan: &PyramidPlan, src: &Raster, budget: u64) -> bool {
+    let sink = MemorySink::new();
+    EngineBuilder::new(RasterStripSource::new(src), plan.clone(), &sink)
+        .with_engine(EngineKind::Streaming)
+        .with_config(EngineConfig::default())
+        .with_memory_budget(budget)
+        .with_budget_policy(BudgetPolicy::Error)
+        .run()
+        .is_ok()
+}
+
+/// #47 is resolved WON'T-FIX: [`streaming_budget_for`] keeps re-deriving the
+/// streaming / mapreduce engines' pre-flight admission invariant
+/// (`canvas_width × 2·tile_size × bpp`) because the core exposes no public
+/// inverse to adopt and coupling the deliberately-raw, saturation-guarded,
+/// plan-less-callable helper to a `&PyramidPlan` is out of proportion to the
+/// coupling (see the helper's docs). This pin gives the duplication teeth by
+/// tying it to the engine's ACTUAL behaviour rather than a same-shaped formula:
+/// the real engine must REJECT a budget one byte below the invariant and ADMIT
+/// one exactly at it. If the core ever changes its admission rule, this goes
+/// red — the signal to revisit the "won't-fix". The mapreduce engine gates on
+/// the identical invariant, so pinning streaming pins the shared formula.
+#[test]
+fn streaming_budget_min_strip_agrees_with_core_preflight() {
+    let src = gradient_raster(1024, 1024);
+    let plan = PyramidPlanner::new(1024, 1024, BENCH_TILE_SIZE, 0, Layout::DeepZoom)
+        .expect("plan the pyramid")
+        .plan();
+    let bpp = src.format().bytes_per_pixel() as u32;
+
+    // The invariant the bench re-derives in `streaming_budget_for`.
+    let min_strip = plan.canvas_width as u64 * 2 * plan.tile_size as u64 * bpp as u64;
+
+    // Reality check: the real engine rejects one byte below the invariant and
+    // admits exactly at it, so the bench's re-derived threshold IS the core's
+    // pre-flight gate — not merely a same-shaped formula (issue #47).
+    assert!(
+        !streaming_admits(&plan, &src, min_strip - 1),
+        "core must reject a budget one byte below its worst-case-strip pre-flight gate"
+    );
+    assert!(
+        streaming_admits(&plan, &src, min_strip),
+        "core must admit a budget exactly at its worst-case-strip pre-flight gate"
+    );
+
+    // And the shared sizing helper sizes strictly above that gate (the fixed 2×
+    // margin), so every streaming-family bench path clears pre-flight with slack.
+    let sized = streaming_budget_for(0, plan.canvas_width, plan.tile_size, bpp);
+    assert_eq!(sized, min_strip * 2, "the fixed 2× pre-flight margin");
+    assert!(
+        sized >= min_strip,
+        "the sized budget must admit the gate strip"
     );
 }

--- a/tests/budget_hardening.rs
+++ b/tests/budget_hardening.rs
@@ -14,7 +14,9 @@
 //! up front with [`EngineError::PlanSourceMismatch`](libviprs::EngineError)
 //! (validated at `run()` entry) — and pin that the bench cell:
 //!   * does NOT unwind — so the report/sweep driver degrades it to a skipped
-//!     row instead of aborting the whole engine series; and
+//!     row instead of aborting the whole engine series;
+//!   * SURFACES the fault as `Err` — not a spurious `Ok` that would push a
+//!     garbage row into the report; and
 //!   * leaves NO temp output dir behind — the reclaim runs on the error path.
 //!
 //! They need no libvips (pure-Rust libviprs engines), so they run
@@ -27,8 +29,8 @@ use std::path::PathBuf;
 
 use libviprs::streaming::BudgetPolicy;
 use libviprs::{
-    EngineBuilder, EngineConfig, EngineKind, Layout, MemorySink, PyramidPlan, PyramidPlanner,
-    Raster, RasterStripSource,
+    EngineBuilder, EngineConfig, EngineError, EngineKind, Layout, MemorySink, PyramidPlan,
+    PyramidPlanner, Raster, RasterStripSource,
 };
 use libviprs_bench::{
     BENCH_STREAMING_BUDGET, BENCH_TILE_SIZE, bench_mapreduce, bench_streaming, gradient_raster,
@@ -68,10 +70,21 @@ fn streaming_cell_fault_does_not_panic_or_leak() {
     let outcome = catch_unwind(AssertUnwindSafe(|| {
         bench_streaming(&src, &plan, 0, BENCH_STREAMING_BUDGET, label)
     }));
+    // Must not unwind (the `catch_unwind` is `Ok`) AND must surface the fault as
+    // `Err` — not swallow it into a spurious `Ok` that would push a garbage row
+    // into the report. Pinning the `PlanSourceMismatch` variant ties the guard
+    // to the real fault this fixture provokes.
+    let returned = match outcome {
+        Ok(returned) => returned,
+        Err(_) => panic!(
+            "bench_streaming unwound on an engine fault instead of returning \
+             (issue #46: the whole report/sweep would abort)"
+        ),
+    };
     assert!(
-        outcome.is_ok(),
-        "bench_streaming unwound on an engine fault instead of returning \
-         (issue #46: the whole report/sweep would abort)"
+        matches!(returned, Err(EngineError::PlanSourceMismatch { .. })),
+        "bench_streaming must RETURN the fault as Err(PlanSourceMismatch), not \
+         swallow it into Ok (issue #46); got {returned:?}"
     );
 
     // #46: and the temp output dir must be reclaimed on the error path.
@@ -92,10 +105,17 @@ fn mapreduce_cell_fault_does_not_panic_or_leak() {
     let outcome = catch_unwind(AssertUnwindSafe(|| {
         bench_mapreduce(&src, &plan, 0, BENCH_STREAMING_BUDGET, label)
     }));
+    let returned = match outcome {
+        Ok(returned) => returned,
+        Err(_) => panic!(
+            "bench_mapreduce unwound on an engine fault instead of returning \
+             (issue #46: the whole report/sweep would abort)"
+        ),
+    };
     assert!(
-        outcome.is_ok(),
-        "bench_mapreduce unwound on an engine fault instead of returning \
-         (issue #46: the whole report/sweep would abort)"
+        matches!(returned, Err(EngineError::PlanSourceMismatch { .. })),
+        "bench_mapreduce must RETURN the fault as Err(PlanSourceMismatch), not \
+         swallow it into Ok (issue #46); got {returned:?}"
     );
     assert!(
         !out_dir.exists(),
@@ -108,31 +128,40 @@ fn mapreduce_cell_fault_does_not_panic_or_leak() {
 // #47: the re-derived budget-admission formula, pinned to core reality.
 // ---------------------------------------------------------------------------
 
-/// Whether the REAL streaming engine admits a run at `budget` — the observable
+/// Run the REAL `kind` engine at `budget` against `plan`/`src` under the strict
+/// [`BudgetPolicy::Error`], returning the engine's own result — the observable
 /// image of the core's up-front pre-flight gate. Uses an in-memory sink so the
-/// probe touches no filesystem.
-fn streaming_admits(plan: &PyramidPlan, src: &Raster, budget: u64) -> bool {
+/// probe touches no filesystem, and `concurrency 0` (the [`EngineConfig`]
+/// default) so no channel-backlog charge clouds the pure strip-budget gate.
+fn engine_admission(
+    kind: EngineKind,
+    plan: &PyramidPlan,
+    src: &Raster,
+    budget: u64,
+) -> Result<(), EngineError> {
     let sink = MemorySink::new();
     EngineBuilder::new(RasterStripSource::new(src), plan.clone(), &sink)
-        .with_engine(EngineKind::Streaming)
+        .with_engine(kind)
         .with_config(EngineConfig::default())
         .with_memory_budget(budget)
         .with_budget_policy(BudgetPolicy::Error)
         .run()
-        .is_ok()
+        .map(|_| ())
 }
 
 /// #47 is resolved WON'T-FIX: [`streaming_budget_for`] keeps re-deriving the
 /// streaming / mapreduce engines' pre-flight admission invariant
-/// (`canvas_width × 2·tile_size × bpp`) because the core exposes no public
-/// inverse to adopt and coupling the deliberately-raw, saturation-guarded,
-/// plan-less-callable helper to a `&PyramidPlan` is out of proportion to the
-/// coupling (see the helper's docs). This pin gives the duplication teeth by
-/// tying it to the engine's ACTUAL behaviour rather than a same-shaped formula:
-/// the real engine must REJECT a budget one byte below the invariant and ADMIT
-/// one exactly at it. If the core ever changes its admission rule, this goes
-/// red — the signal to revisit the "won't-fix". The mapreduce engine gates on
-/// the identical invariant, so pinning streaming pins the shared formula.
+/// (`canvas_width × 2·tile_size × bpp` — each engine's `worst_case_strip_bytes`)
+/// because the core exposes no public accessor to adopt and coupling the
+/// deliberately-raw, saturation-guarded, plan-less-callable helper to a
+/// `&PyramidPlan` is out of proportion to the coupling (see the helper's docs).
+/// This pin gives the duplication teeth by tying it to the engines' ACTUAL
+/// behaviour rather than a same-shaped formula: BOTH engines must REJECT a
+/// budget one byte below the invariant — specifically with `BudgetExceeded`, so
+/// an unrelated failure can't let the pin pass for the wrong reason — and ADMIT
+/// one exactly at it. The core keeps two INDEPENDENT copies of the gate
+/// (`streaming` and `streaming_mapreduce`), so driving BOTH means a drift in
+/// either turns this red — the signal to revisit the "won't-fix".
 #[test]
 fn streaming_budget_min_strip_agrees_with_core_preflight() {
     let src = gradient_raster(1024, 1024);
@@ -144,24 +173,35 @@ fn streaming_budget_min_strip_agrees_with_core_preflight() {
     // The invariant the bench re-derives in `streaming_budget_for`.
     let min_strip = plan.canvas_width as u64 * 2 * plan.tile_size as u64 * bpp as u64;
 
-    // Reality check: the real engine rejects one byte below the invariant and
-    // admits exactly at it, so the bench's re-derived threshold IS the core's
-    // pre-flight gate — not merely a same-shaped formula (issue #47).
-    assert!(
-        !streaming_admits(&plan, &src, min_strip - 1),
-        "core must reject a budget one byte below its worst-case-strip pre-flight gate"
-    );
-    assert!(
-        streaming_admits(&plan, &src, min_strip),
-        "core must admit a budget exactly at its worst-case-strip pre-flight gate"
-    );
+    // Reality check, for BOTH engines (each gates on its own copy of the
+    // invariant): the real engine rejects one byte below the gate — with
+    // `BudgetExceeded` specifically — and admits exactly at it, so the bench's
+    // re-derived threshold IS the core's pre-flight gate, not merely a
+    // same-shaped formula (issue #47).
+    for kind in [EngineKind::Streaming, EngineKind::MapReduce] {
+        assert!(
+            matches!(
+                engine_admission(kind, &plan, &src, min_strip - 1),
+                Err(EngineError::BudgetExceeded { .. })
+            ),
+            "{kind:?}: core must reject a budget one byte below its \
+             worst-case-strip pre-flight gate with BudgetExceeded"
+        );
+        assert!(
+            engine_admission(kind, &plan, &src, min_strip).is_ok(),
+            "{kind:?}: core must admit a budget exactly at its worst-case-strip \
+             pre-flight gate"
+        );
+    }
 
-    // And the shared sizing helper sizes strictly above that gate (the fixed 2×
-    // margin), so every streaming-family bench path clears pre-flight with slack.
+    // The shared sizing helper sizes to a fixed 2× margin above that gate. This
+    // documents the margin the bench applies — it is NOT an independent pin of
+    // the core (the admission pairs above are); it changes only if the helper's
+    // own formula changes.
     let sized = streaming_budget_for(0, plan.canvas_width, plan.tile_size, bpp);
-    assert_eq!(sized, min_strip * 2, "the fixed 2× pre-flight margin");
-    assert!(
-        sized >= min_strip,
-        "the sized budget must admit the gate strip"
+    assert_eq!(
+        sized,
+        min_strip * 2,
+        "documents the fixed 2× pre-flight margin"
     );
 }

--- a/tests/budget_hardening.rs
+++ b/tests/budget_hardening.rs
@@ -1,0 +1,100 @@
+//! #46: streaming / mapreduce bench cells must fail SOFT (no panic, no leak).
+//!
+//! [`bench_streaming`](libviprs_bench::bench_streaming) and
+//! [`bench_mapreduce`](libviprs_bench::bench_mapreduce) run under the strict
+//! [`BudgetPolicy::Error`]. Before #46 they ended in `.run().unwrap()`, so a
+//! genuine (non-budget) engine fault — a sink IO error, a source error, or the
+//! entry-time plan/source dimension guard — PANICKED the whole report/sweep
+//! and, because the panic fired before the `remove_dir_all`, leaked the temp
+//! output dir under `$TMPDIR`. #38 removed only the *budget-driven* trigger of
+//! that panic; the fragile pattern itself remained.
+//!
+//! These guards drive a real, deterministic engine fault — a plan built for
+//! larger dimensions than the source raster, which every engine kind rejects
+//! up front with [`EngineError::PlanSourceMismatch`](libviprs::EngineError)
+//! (validated at `run()` entry) — and pin that the bench cell:
+//!   * does NOT unwind — so the report/sweep driver degrades it to a skipped
+//!     row instead of aborting the whole engine series; and
+//!   * leaves NO temp output dir behind — the reclaim runs on the error path.
+//!
+//! They need no libvips (pure-Rust libviprs engines), so they run
+//! unconditionally. They are written with [`catch_unwind`] so the SAME
+//! assertion — "the call returned rather than unwinding" — is meaningful
+//! against both the pre-#46 panicking signature and the post-#46 `Result` one.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::PathBuf;
+
+use libviprs::{Layout, PyramidPlan, PyramidPlanner, Raster};
+use libviprs_bench::{
+    BENCH_STREAMING_BUDGET, BENCH_TILE_SIZE, bench_mapreduce, bench_streaming, gradient_raster,
+};
+
+/// A 256×256 source paired with a plan built for 1024×1024. The engine's
+/// entry-time plan/source dimension guard rejects this up front with
+/// `PlanSourceMismatch` — a genuine, non-budget engine fault that is fully
+/// deterministic and needs no filesystem tampering to provoke.
+fn mismatched_source_and_plan() -> (Raster, PyramidPlan) {
+    let src = gradient_raster(256, 256);
+    let plan = PyramidPlanner::new(1024, 1024, BENCH_TILE_SIZE, 0, Layout::DeepZoom)
+        .expect("plan the (deliberately mismatched) pyramid")
+        .plan();
+    (src, plan)
+}
+
+/// The temp output dir a cell roots its tiles at — mirrors the crate's private
+/// `fs_sink_dir` layout (`TMPDIR/libviprs-bench/engine_{pid}_{label}`) so the
+/// test can assert the cell left nothing behind on the error path.
+fn cell_out_dir(label: &str) -> PathBuf {
+    std::env::temp_dir()
+        .join("libviprs-bench")
+        .join(format!("engine_{}_{label}", std::process::id()))
+}
+
+#[test]
+fn streaming_cell_fault_does_not_panic_or_leak() {
+    let (src, plan) = mismatched_source_and_plan();
+    let label = "budget46_streaming_fault";
+    let out_dir = cell_out_dir(label);
+    let _ = std::fs::remove_dir_all(&out_dir);
+
+    // #46: a genuine engine fault must be RETURNED, not unwound up through the
+    // report/sweep driver (which would drop the whole streaming series).
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        bench_streaming(&src, &plan, 0, BENCH_STREAMING_BUDGET, label)
+    }));
+    assert!(
+        outcome.is_ok(),
+        "bench_streaming unwound on an engine fault instead of returning \
+         (issue #46: the whole report/sweep would abort)"
+    );
+
+    // #46: and the temp output dir must be reclaimed on the error path.
+    assert!(
+        !out_dir.exists(),
+        "bench_streaming leaked its temp output dir {} on the error path (issue #46)",
+        out_dir.display()
+    );
+}
+
+#[test]
+fn mapreduce_cell_fault_does_not_panic_or_leak() {
+    let (src, plan) = mismatched_source_and_plan();
+    let label = "budget46_mapreduce_fault";
+    let out_dir = cell_out_dir(label);
+    let _ = std::fs::remove_dir_all(&out_dir);
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        bench_mapreduce(&src, &plan, 0, BENCH_STREAMING_BUDGET, label)
+    }));
+    assert!(
+        outcome.is_ok(),
+        "bench_mapreduce unwound on an engine fault instead of returning \
+         (issue #46: the whole report/sweep would abort)"
+    );
+    assert!(
+        !out_dir.exists(),
+        "bench_mapreduce leaked its temp output dir {} on the error path (issue #46)",
+        out_dir.display()
+    );
+}

--- a/tests/streaming_budget.rs
+++ b/tests/streaming_budget.rs
@@ -86,7 +86,8 @@ fn report_default_budget_admits_large_streaming_pyramid() {
         .plan();
 
     // Exactly the budget/policy the report drives every streaming cell with.
-    let m = bench_streaming(&src, &plan, 0, BENCH_STREAMING_BUDGET, "budget38_stream");
+    let m = bench_streaming(&src, &plan, 0, BENCH_STREAMING_BUDGET, "budget38_stream")
+        .expect("the sized budget must admit the streaming run, not error");
 
     assert_valid_large_pyramid(&m, "streaming");
 }
@@ -101,7 +102,8 @@ fn report_default_budget_admits_large_mapreduce_pyramid() {
         .expect("plan the pyramid")
         .plan();
 
-    let m = bench_mapreduce(&src, &plan, 0, BENCH_STREAMING_BUDGET, "budget38_mr");
+    let m = bench_mapreduce(&src, &plan, 0, BENCH_STREAMING_BUDGET, "budget38_mr")
+        .expect("the sized budget must admit the mapreduce run, not error");
 
     assert_valid_large_pyramid(&m, "mapreduce");
 }

--- a/tests/vips_ffi.rs
+++ b/tests/vips_ffi.rs
@@ -99,7 +99,8 @@ fn engines_share_sink_and_report_separate_memory_columns() {
         libviprs::PyramidPlanner::new(512, 512, 256, 0, libviprs::Layout::DeepZoom).unwrap();
     let plan = planner.plan();
 
-    let mono = libviprs_bench::bench_monolithic(&raster, &plan, 1, "fair_mono");
+    let mono = libviprs_bench::bench_monolithic(&raster, &plan, 1, "fair_mono")
+        .expect("monolithic run should succeed on a matched source/plan");
     let vips = libviprs_bench::bench_libvips_inprocess(&raster, 256, 1, "fair_vips")
         .expect("libvips in-process bench returned None");
 


### PR DESCRIPTION
Resolves **#46** (fixed) and **#47** (documented won't-fix). #46: bench_streaming/bench_mapreduce (and monolithic) now return `Result` instead of `.run().unwrap()`, with a self-reclaiming `TempOutDir` RAII guard (unwind-safe, no temp-dir leak on the error path); callers unified behind `skip_on_engine_fault`/`warn_engine_skip` so a failed cell degrades to skipped+warned rather than aborting the report/sweep. #47: evaluated core — no suitable public primitive exists (only the forward/full-working-set estimates, not the inverse); kept the tested formula and added a reality-pin test (`engine_admission` drives BOTH streaming+mapreduce, asserts rejection at min-1 is specifically `BudgetExceeded`) that goes red if core's admission rule drifts. Documented rationale on the helper (strawman corrected); `budget`→`budget_floor` rename for clarity.

TDD RED→GREEN. 4-expert review applied. **Convergence mode: no new issues filed.** Local gate green.

Closes #46
Closes #47