### PR TITLE
Residual sweep: metric labels, tables, thermal/load provenance, flamegraph weighting, docs (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The harness produces:
 | `benches/engine_comparison.rs` | Criterion micro-benchmarks for monolithic / streaming / MapReduce, plus a head-to-head group across image sizes. |
 | `src/scalability.rs` (`scalability` bin) | Scalability sweep from 0.2 MP to 47 MP, comparing all four engines on a 1.42:1 aspect ratio matching `43551_California_South.pdf`. |
 | `src/report.rs` (`report` bin) | Full comparison matrix across image sizes and concurrency levels, with versioned history. |
-| `src/flamegraph.rs` (`flamegraph` bin) | Event-based flame graphs for all three libviprs engines on a 4096x4096 image. |
+| `src/flamegraph.rs` (`flamegraph` bin) | Time-weighted flame graphs (frame width = per-tile µs) for all three libviprs engines on a 4096x4096 image. |
 
 ## Running benchmarks
 
@@ -143,22 +143,27 @@ Four benchmark groups, each parameterised on image size:
   [`--memory-budget`](https://libviprs.org/cli/#flag-memory-budget) /
   [`--concurrency`](https://libviprs.org/cli/#flag-concurrency) tradeoff.
 
-### `pdf_engine_bench` (`src/pdf_engine_bench.rs`)
+### `pdfium_strip_source_bench` (`src/pdfium_strip_source_bench.rs`, `pdfium` feature)
 
-Renders one PDF page through one engine and writes a JSON report. The CLI
-flags it accepts mirror the libviprs CLI:
+Compares the two `PdfiumStripSource` constructors — cached (`new`) versus
+streaming (`new_streaming`) — over a `(dpi, strip_count)` sweep on a PDF,
+emitting one newline-delimited JSON record per `(mode, dpi, strips)` triple. The
+numbers back the "vector-heavy PDFs scale ~linearly with N, raster-heavy
+approach 1×" doc comment on `PdfiumStripSource::new_streaming` with data instead
+of assertion. Gated behind the `pdfium` feature.
 
-| `pdf_engine_bench` flag | CLI equivalent                                              |
-|-------------------------|-------------------------------------------------------------|
-| `--engine mono\|stream` | engine selection (see CLI flag picker)                      |
-| `--budget-bytes`        | [`--memory-budget`](https://libviprs.org/cli/#flag-memory-budget) |
-| `--tile-size`           | [pyramid layout](https://libviprs.org/cli/#pyramid)         |
-| `--dpi`, `--page`, `--layout` | matched 1:1 in the CLI                                |
+| `pdfium_strip_source_bench` flag | Meaning                                                                  |
+|----------------------------------|--------------------------------------------------------------------------|
+| `--pdf <path>`                   | PDF to bench (default: the committed `fixtures/cc_licenses_mapping.pdf`)  |
+| `--page <N>`                     | 1-based page index                                                       |
+| `--dpis 72,150,300`              | comma-separated render DPIs to sweep                                      |
+| `--strip-counts 4,16,64`         | comma-separated strip counts to sweep                                    |
+| `--output <file.jsonl>`          | write JSONL here instead of stdout                                       |
 
-Streaming runs additionally honour an internal strip-buffer sizing knob
-analogous to [`--buffer-size`](https://libviprs.org/cli/#flag-buffer-size);
-the bench fixes it via `compute_strip_height` against the budget so the
-two engines see byte-identical input dimensions.
+```bash
+cargo run --release --features pdfium --bin pdfium_strip_source_bench -- \
+    --pdf /path/to/blueprint.pdf --dpis 72,150,300 --strip-counts 4,16,64
+```
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The harness produces:
 | `benches/engine_comparison.rs` | Criterion micro-benchmarks for monolithic / streaming / MapReduce, plus a head-to-head group across image sizes. |
 | `src/scalability.rs` (`scalability` bin) | Scalability sweep from 0.2 MP to 47 MP, comparing all four engines on a 1.42:1 aspect ratio matching `43551_California_South.pdf`. |
 | `src/report.rs` (`report` bin) | Full comparison matrix across image sizes and concurrency levels, with versioned history. |
-| `src/flamegraph.rs` (`flamegraph` bin) | Time-weighted flame graphs (frame width = per-tile µs) for all three libviprs engines on a 4096x4096 image. |
+| `src/flamegraph.rs` (`flamegraph` bin) | Time-weighted flame graphs (frame width = µs) for all three libviprs engines on a 4096x4096 image. Per-tile widths are faithful for the serial monolithic engine; for the strip-based streaming/MapReduce engines read them at level/root granularity (per-tile widths are emission cadence). |
 
 ## Running benchmarks
 

--- a/run-bench.sh
+++ b/run-bench.sh
@@ -27,8 +27,36 @@ MEMORY_MB=""
 BENCH_CMD="scalability"
 VERSIONS=""
 
+usage() {
+    cat <<'EOF'
+run-bench.sh — build and run libviprs benchmarks (in Docker by default)
+
+Usage:
+  ./run-bench.sh [scalability|report|versions] [options]
+
+Commands (default: scalability):
+  scalability   Engine scalability sweep  -> report/scalability_results.json
+  report        Full comparison matrix    -> report/benchmark_{results,history}.json
+  versions      Release-history axis (requires --versions)
+
+Options:
+  --versions <tag,tag,HEAD>   Refs to benchmark for the 'versions' command
+  --arch <arm|amd64>          Force the target architecture (default: host uname -m)
+  --memory <MB>               Container memory limit in MB (default: 4096)
+  --no-build                  Run on the host without Docker (needs libvips-dev + pkg-config)
+  -h, --help                  Show this help and exit
+
+After the harness writes its JSON, the SVG charts are rendered on the host by
+tools/charts/render.mjs (needs Node; skipped with a hint if Node is absent).
+EOF
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
         --no-build) NO_BUILD=true ;;
         --memory)
             shift
@@ -53,8 +81,8 @@ while [[ $# -gt 0 ]]; do
             BENCH_CMD="version_matrix"
             ;;
         *)
-            echo "Unknown argument: $1"
-            echo "Usage: $0 [scalability|report|versions] [--versions v0.2.0,v0.3.1,HEAD] [--arch arm|amd64] [--memory MB] [--no-build]"
+            echo "Unknown argument: $1" >&2
+            echo "Run '$0 --help' for usage." >&2
             exit 1
             ;;
     esac

--- a/src/cross_version.rs
+++ b/src/cross_version.rs
@@ -216,6 +216,12 @@ fn write_markdown_report(df: &DataFrame, versions: &[String], path: &PathBuf) {
          delta vs the previous version. Columns are one per \
          `version@short_sha` on record, ordered by (semver, timestamp).\n\n",
     );
+    out.push_str(
+        "Each metric heading states its unit and its better-direction (higher- or \
+         lower-is-better). Delta markers: ✅ moved in the better direction; ⚠️ regressed; \
+         ≈ within the combined 95% CI (a statistical tie); `env≠` measured in a different \
+         environment (not comparable — see the fingerprint).\n\n",
+    );
 
     // The size axis is derived from the frame; the version (column) axis is
     // supplied pre-ordered by (semver, timestamp) so releases read in release
@@ -244,7 +250,12 @@ fn write_markdown_report(df: &DataFrame, versions: &[String], path: &PathBuf) {
             ),
         ] {
             let (col, title, higher_is_better, ci_col) = metric;
-            out.push_str(&format!("### {title}\n\n"));
+            let direction = if higher_is_better {
+                "higher is better"
+            } else {
+                "lower is better"
+            };
+            out.push_str(&format!("### {title} — {direction}\n\n"));
             out.push_str(&render_metric_table(
                 df,
                 *w,

--- a/src/flame.rs
+++ b/src/flame.rs
@@ -1,0 +1,75 @@
+//! Time-weighted folded-stack construction for the `flamegraph` binary.
+//!
+//! A flame graph's frame WIDTH is proportional to its sample weight, so for the
+//! width to mean *time* the weight must be time — not a flat per-event count. The
+//! in-tree engines stamp each [`EngineEvent::TileCompleted`] with a
+//! coordinating-thread timestamp (issue #67), so the wall-clock gap between one
+//! tile and the next is that tile's production time. [`events_to_folded_stacks`]
+//! folds those gaps into inferno's `stack <weight>` format with the weight in
+//! MICROSECONDS, and [`tile_weight_micros`] is the pure per-tile conversion.
+//!
+//! Only time-weighted tile frames are emitted (`engine;level_N;tile_rR_cC`). The
+//! earlier folded output also injected standalone marker lines whose weight was a
+//! tile COUNT (`level_N_start <tile_count>`, `level_N_complete <tiles_produced>`)
+//! — a count on a time axis, which made those frames dwarf the tiles they
+//! summarised. Those markers are gone; the level grouping survives as the parent
+//! frame of its tiles.
+
+use std::time::SystemTime;
+
+use libviprs::EngineEvent;
+
+/// inferno `--countname` for the time-weighted graph: the sample unit is
+/// microseconds of wall time, not a count of events.
+pub const FLAMEGRAPH_COUNT_NAME: &str = "microseconds";
+
+/// Convert the wall-clock gap between the previous tile and this one into a
+/// flame-graph sample weight, in microseconds.
+///
+/// The weight floors at 1: inferno silently drops a zero-count frame, and the
+/// first tile in a stream (no predecessor), a missing timestamp, a zero gap, or
+/// a backwards clock (skew) would otherwise yield 0 — so each still contributes a
+/// single-microsecond sliver rather than vanishing. A backwards gap is clamped
+/// rather than allowed to underflow.
+pub fn tile_weight_micros(prev: Option<SystemTime>, cur: Option<SystemTime>) -> u64 {
+    match (prev, cur) {
+        (Some(prev), Some(cur)) => cur
+            .duration_since(prev)
+            .map(|d| d.as_micros() as u64)
+            .unwrap_or(0)
+            .max(1),
+        _ => 1,
+    }
+}
+
+/// Fold an engine's observer event stream into inferno's `stack <weight>` lines,
+/// weighting each tile frame by the time it took (see [`tile_weight_micros`]).
+///
+/// Each [`EngineEvent::TileCompleted`] becomes one frame
+/// `engine;level_<level>;tile_r<row>_c<col> <micros>`, nested under its pyramid
+/// level so the level frame's width is the total time spent in that level and the
+/// root's width is the total tiling time. Non-tile events (level / strip / batch
+/// / finished markers) are structural, carry no timestamp, and are NOT emitted —
+/// folding them in with a fabricated weight would put non-time area on a time
+/// axis.
+pub fn events_to_folded_stacks(events: &[EngineEvent], engine_name: &str) -> Vec<String> {
+    let mut stacks = Vec::new();
+    // Timestamp of the previous tile, so this tile's weight is the gap since it.
+    let mut prev_tile_ts: Option<SystemTime> = None;
+
+    for event in events {
+        if let EngineEvent::TileCompleted {
+            coord, timestamp, ..
+        } = event
+        {
+            let weight = tile_weight_micros(prev_tile_ts, *timestamp);
+            stacks.push(format!(
+                "{engine_name};level_{};tile_r{}_c{} {weight}",
+                coord.level, coord.row, coord.col
+            ));
+            prev_tile_ts = *timestamp;
+        }
+    }
+
+    stacks
+}

--- a/src/flame.rs
+++ b/src/flame.rs
@@ -3,17 +3,39 @@
 //! A flame graph's frame WIDTH is proportional to its sample weight, so for the
 //! width to mean *time* the weight must be time — not a flat per-event count. The
 //! in-tree engines stamp each [`EngineEvent::TileCompleted`] with a
-//! coordinating-thread timestamp (issue #67), so the wall-clock gap between one
-//! tile and the next is that tile's production time. [`events_to_folded_stacks`]
-//! folds those gaps into inferno's `stack <weight>` format with the weight in
-//! MICROSECONDS, and [`tile_weight_micros`] is the pure per-tile conversion.
+//! coordinating-thread timestamp (issue #67), so [`events_to_folded_stacks`]
+//! folds the wall-clock gap between consecutive tiles into inferno's
+//! `stack <weight>` format with the weight in MICROSECONDS, and
+//! [`tile_weight_micros`] is the pure per-tile conversion.
 //!
-//! Only time-weighted tile frames are emitted (`engine;level_N;tile_rR_cC`). The
-//! earlier folded output also injected standalone marker lines whose weight was a
-//! tile COUNT (`level_N_start <tile_count>`, `level_N_complete <tiles_produced>`)
-//! — a count on a time axis, which made those frames dwarf the tiles they
-//! summarised. Those markers are gone; the level grouping survives as the parent
-//! frame of its tiles.
+//! # What a frame width means — and when
+//!
+//! The inter-tile gap equals a single tile's *production* time only when tiles
+//! are produced and emitted ONE AT A TIME, IN ORDER, on ONE thread. That holds
+//! for the **monolithic** engine, which extracts and writes tiles in a serial
+//! row-major loop, so its per-tile widths are faithful per-tile times. It does
+//! NOT hold for the strip-based **streaming** and **MapReduce** engines: each
+//! renders a whole strip and then emits that strip's tiles back-to-back, so the
+//! first tile of a strip absorbs the strip's render time and the rest drain in
+//! near-zero gaps. Under tile concurrency (`tile_concurrency > 0`)
+//! `TileCompleted` is additionally emitted in channel-*arrival* order — an
+//! interleaving the core documents as arbitrary (see
+//! `streaming_mapreduce::emit_strip_tiles_parallel`) — so a per-tile width there
+//! is a coordinator drain delta, not that tile's compute time.
+//!
+//! What stays true for EVERY engine is the AGGREGATE: each tile's weight is the
+//! gap since the previous one, so the widths tile the timeline by construction —
+//! a level frame's width is the total wall time spent producing that level and
+//! the root's width is the total tiling time. Read the strip-based graphs at
+//! level/root granularity; read only the monolithic graph tile-by-tile. The SVG
+//! titles say which is which.
+//!
+//! Only tile frames are emitted (`engine;level_N;tile_rR_cC`). The earlier folded
+//! output also injected standalone marker lines whose weight was a tile COUNT
+//! (`level_N_start <tile_count>`, `level_N_complete <tiles_produced>`) — a count
+//! on a time axis, which made those frames dwarf the tiles they summarised. Those
+//! markers are gone; the level grouping survives as the parent frame of its
+//! tiles.
 
 use std::time::SystemTime;
 
@@ -26,11 +48,19 @@ pub const FLAMEGRAPH_COUNT_NAME: &str = "microseconds";
 /// Convert the wall-clock gap between the previous tile and this one into a
 /// flame-graph sample weight, in microseconds.
 ///
+/// Argument order is `(prev, cur)`: the *previous* tile's emit timestamp, then
+/// *this* tile's. Passing them the other way round is masked by the backwards-
+/// clock clamp below (it returns 1 rather than the true gap), so mind the order.
+///
 /// The weight floors at 1: inferno silently drops a zero-count frame, and the
 /// first tile in a stream (no predecessor), a missing timestamp, a zero gap, or
 /// a backwards clock (skew) would otherwise yield 0 — so each still contributes a
 /// single-microsecond sliver rather than vanishing. A backwards gap is clamped
 /// rather than allowed to underflow.
+///
+/// See the module docs for when the resulting width is a faithful per-tile time
+/// (serial monolithic engine) versus an emission-cadence artifact (the strip-
+/// based streaming / MapReduce engines).
 pub fn tile_weight_micros(prev: Option<SystemTime>, cur: Option<SystemTime>) -> u64 {
     match (prev, cur) {
         (Some(prev), Some(cur)) => cur
@@ -52,6 +82,11 @@ pub fn tile_weight_micros(prev: Option<SystemTime>, cur: Option<SystemTime>) -> 
 /// / finished markers) are structural, carry no timestamp, and are NOT emitted —
 /// folding them in with a fabricated weight would put non-time area on a time
 /// axis.
+///
+/// This is a public function that accepts any event stream. Per-tile widths are
+/// faithful per-tile times only for a SERIAL, in-order producer (the monolithic
+/// engine); for a strip-batched or concurrent stream only the aggregate
+/// level/root width is a true wall-time measure — see the module docs.
 pub fn events_to_folded_stacks(events: &[EngineEvent], engine_name: &str) -> Vec<String> {
     let mut stacks = Vec::new();
     // Timestamp of the previous tile, so this tile's weight is the gap since it.

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -35,6 +35,17 @@ const HEIGHT: u32 = 4096;
 const TILE_SIZE: u32 = 256;
 
 fn generate_flamegraph(stacks: &[String], output_path: &Path, title: &str) {
+    if stacks.is_empty() {
+        // inferno's `from_reader` errors on empty input, which the `.expect`
+        // below would turn into a panic. A zero-tile run (no `TileCompleted`
+        // events) legitimately folds to no frames — skip the SVG with a notice
+        // rather than abort. Latent for the fixed 4096² workload (which always
+        // produces tiles), but #25 dropped the marker frames that used to
+        // guarantee non-empty output, so guard the regression (#25 review).
+        eprintln!("  (no tiles produced — skipping {})", output_path.display());
+        return;
+    }
+
     let mut opts = Options::default();
     opts.title = title.to_string();
     // The sample unit is microseconds of wall time (see the flame module), not a
@@ -100,7 +111,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         generate_flamegraph(
             &stacks,
             &path,
-            "libviprs monolithic engine — time-weighted tile flame graph (width = µs)",
+            "libviprs monolithic engine — time-weighted flame graph \
+             (per-tile width = µs; serial engine, faithful per tile)",
         );
         println!("  → {}", path.display());
     }
@@ -140,7 +152,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         generate_flamegraph(
             &stacks,
             &path,
-            "libviprs streaming engine — time-weighted tile flame graph (width = µs)",
+            "libviprs streaming engine — time-weighted flame graph \
+             (width = µs; read at level/root — per-tile widths are strip-emission cadence)",
         );
         println!("  → {}", path.display());
     }
@@ -185,7 +198,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         generate_flamegraph(
             &stacks,
             &path,
-            "libviprs MapReduce engine — time-weighted tile flame graph (width = µs)",
+            "libviprs MapReduce engine — time-weighted flame graph \
+             (width = µs; read at level/root — per-tile widths are emission cadence)",
         );
         println!("  → {}", path.display());
     }

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -1,13 +1,19 @@
-//! Generates flame graphs for monolithic and streaming engines.
+//! Generates time-weighted flame graphs for all three libviprs engines.
 //!
-//! Uses tracing-based self-instrumentation and the inferno crate to produce
-//! SVG flame graphs in the `report/` directory.
+//! Drives each engine on a 4096x4096 image under a [`CollectingObserver`], then
+//! folds the captured [`EngineEvent`](libviprs::EngineEvent) stream into
+//! inferno's `stack <weight>` format via
+//! [`libviprs_bench::flame::events_to_folded_stacks`] and renders an SVG per
+//! engine. Frame WIDTH is TIME: each tile is weighted by the wall-clock gap since
+//! the previous tile (in microseconds), not by a flat sample count, so a level or
+//! tile that took longer draws wider.
 //!
-//! Run: cargo run --bin flamegraph
+//! Run: cargo run --release --bin flamegraph
 //!
-//! This binary profiles both engines on a 4096x4096 image and writes:
+//! Writes, into the `report/` directory:
 //!   report/flamegraph_monolithic.svg
 //!   report/flamegraph_streaming.svg
+//!   report/flamegraph_mapreduce.svg
 
 use std::fs::{self, File};
 use std::io::BufWriter;
@@ -20,6 +26,7 @@ use libviprs::{
     CollectingObserver, EngineBuilder, EngineConfig, EngineEvent, EngineKind, Layout, MemorySink,
     PyramidPlanner, RasterStripSource,
 };
+use libviprs_bench::flame::{FLAMEGRAPH_COUNT_NAME, events_to_folded_stacks};
 use libviprs_bench::{gradient_raster, streaming_budget_for};
 use std::sync::Arc;
 
@@ -27,86 +34,12 @@ const WIDTH: u32 = 4096;
 const HEIGHT: u32 = 4096;
 const TILE_SIZE: u32 = 256;
 
-/// Collect a folded-stack trace from engine observer events.
-///
-/// Converts EngineEvent sequences into a folded stack format that inferno
-/// can render as a flame graph. Each event becomes a stack frame with its
-/// duration encoded as the sample count.
-fn events_to_folded_stacks(events: &[EngineEvent], engine_name: &str) -> Vec<String> {
-    let mut stacks = Vec::new();
-    let mut current_level: Option<u32> = None;
-    let mut _level_tiles: u64 = 0;
-
-    for event in events {
-        match event {
-            EngineEvent::LevelStarted {
-                level, tile_count, ..
-            } => {
-                current_level = Some(*level);
-                _level_tiles = 0;
-                stacks.push(format!("{engine_name};level_{level}_start {tile_count}"));
-            }
-            EngineEvent::TileCompleted { coord, .. } => {
-                _level_tiles += 1;
-                if let Some(lvl) = current_level {
-                    stacks.push(format!(
-                        "{engine_name};level_{lvl};tile_r{}_c{} 1",
-                        coord.row, coord.col
-                    ));
-                }
-            }
-            EngineEvent::LevelCompleted {
-                level,
-                tiles_produced,
-            } => {
-                stacks.push(format!(
-                    "{engine_name};level_{level}_complete {tiles_produced}"
-                ));
-            }
-            EngineEvent::StripRendered {
-                strip_index,
-                total_strips,
-            } => {
-                stacks.push(format!(
-                    "{engine_name};strip_{strip_index}_of_{total_strips} 1"
-                ));
-            }
-            EngineEvent::BatchStarted {
-                batch_index,
-                strips_in_batch,
-                ..
-            } => {
-                stacks.push(format!(
-                    "{engine_name};batch_{batch_index}_{strips_in_batch}strips 1"
-                ));
-            }
-            EngineEvent::BatchCompleted {
-                batch_index,
-                tiles_produced,
-            } => {
-                stacks.push(format!(
-                    "{engine_name};batch_{batch_index}_done_{tiles_produced}tiles 1"
-                ));
-            }
-            EngineEvent::Finished {
-                total_tiles,
-                levels,
-            } => {
-                stacks.push(format!(
-                    "{engine_name};finished_{levels}levels_{total_tiles}tiles 1"
-                ));
-            }
-            _ => {}
-        }
-    }
-
-    stacks
-}
-
 fn generate_flamegraph(stacks: &[String], output_path: &Path, title: &str) {
     let mut opts = Options::default();
     opts.title = title.to_string();
-    opts.count_name = "events".to_string();
+    // The sample unit is microseconds of wall time (see the flame module), not a
+    // count of events, so inferno's hover/legend reads in time.
+    opts.count_name = FLAMEGRAPH_COUNT_NAME.to_string();
     opts.min_width = 0.1;
 
     let file = File::create(output_path).expect("create flamegraph file");
@@ -167,7 +100,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         generate_flamegraph(
             &stacks,
             &path,
-            "libviprs monolithic engine — event flame graph",
+            "libviprs monolithic engine — time-weighted tile flame graph (width = µs)",
         );
         println!("  → {}", path.display());
     }
@@ -207,7 +140,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         generate_flamegraph(
             &stacks,
             &path,
-            "libviprs streaming engine — event flame graph",
+            "libviprs streaming engine — time-weighted tile flame graph (width = µs)",
         );
         println!("  → {}", path.display());
     }
@@ -252,7 +185,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         generate_flamegraph(
             &stacks,
             &path,
-            "libviprs MapReduce engine — event flame graph",
+            "libviprs MapReduce engine — time-weighted tile flame graph (width = µs)",
         );
         println!("  → {}", path.display());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ use libviprs::{
 };
 use serde::{Deserialize, Serialize};
 
+pub mod flame;
 pub mod harness;
 pub mod pin_check;
 pub mod provenance;
@@ -1603,9 +1604,48 @@ pub fn comparison_suite(
     results
 }
 
-/// Print a comparison table to stdout.
-pub fn print_comparison_table(results: &[RunMetrics]) {
-    println!(
+/// Units + direction legend shared by every human-readable comparison table so
+/// no metric's unit or better-direction is ever left to a guess (#25). The
+/// primary throughput metric is TILES per second — pyramid tiles
+/// ([`BENCH_TILE_SIZE`] px), never pixels.
+pub const COMPARISON_TABLE_LEGEND: &str = concat!(
+    "Units & direction (T = pyramid tiles, never pixels):\n",
+    "  Time (ms) / Tracked MB / RSS MB ............ lower is better\n",
+    "  T/s        = tiles written per second (throughput) ......... higher is better\n",
+    "  T/s/RSS-MB = throughput per peak-RSS MB (memory efficiency)  higher is better\n",
+    "  RSS-MB\u{00b7}s/tile = RSS-MB-seconds per tile (resource cost) ..... lower is better\n",
+    "Tracked MB is libviprs-internal (0 for libvips); RSS MB is the cross-engine peak.\n",
+    "Figures are warm medians (warm-ups discarded).\n",
+);
+
+/// Insert ASCII thousands separators into an integer: `349525` → `"349,525"`.
+/// Keeps large tile / throughput counts legible in the fixed-width text tables
+/// (#25).
+pub fn thousands(n: u64) -> String {
+    let digits = n.to_string();
+    let bytes = digits.as_bytes();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    for (i, &b) in bytes.iter().enumerate() {
+        if i > 0 && (bytes.len() - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(b as char);
+    }
+    out
+}
+
+/// Render the engine comparison table — header, one row per run, and a
+/// units/direction legend — as a String.
+///
+/// Shared by the stdout [`print_comparison_table`] and the committed
+/// `report/comparison_table.txt` so the two never drift and both carry the
+/// legend that pins every metric's unit and better-direction (#25). Tile and
+/// throughput counts read with thousands separators.
+pub fn comparison_table(results: &[RunMetrics]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
         "{:<24} {:<12} {:>10} {:>12} {:>10} {:>8} {:>8} {:>10} {:>12}",
         "Label",
         "Engine",
@@ -1615,24 +1655,31 @@ pub fn print_comparison_table(results: &[RunMetrics]) {
         "Tiles",
         "T/s",
         "T/s/RSS-MB",
-        "RSS-MB\u{00b7}s/tile"
+        "RSS-MB\u{00b7}s/tile",
     );
-    println!("{}", "-".repeat(112));
-
+    let _ = writeln!(out, "{}", "-".repeat(112));
     for r in results {
-        println!(
-            "{:<24} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>8} {:>8.0} {:>10.1} {:>12.4}",
+        let _ = writeln!(
+            out,
+            "{:<24} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>8} {:>8} {:>10.1} {:>12.4}",
             r.label,
             r.engine,
             r.wall_time_ms(),
             r.tracked_memory_mb(),
             r.peak_rss_mb(),
-            r.tiles_produced,
-            r.tiles_per_second(),
+            thousands(r.tiles_produced),
+            thousands(r.tiles_per_second().round() as u64),
             r.tiles_per_second_per_mb(),
             r.resource_cost_per_tile(),
         );
     }
+    out.push_str(COMPARISON_TABLE_LEGEND);
+    out
+}
+
+/// Print the comparison table (with its units/direction legend) to stdout.
+pub fn print_comparison_table(results: &[RunMetrics]) {
+    print!("{}", comparison_table(results));
 }
 
 /// Group results by config key (width × height × concurrency).
@@ -1823,12 +1870,14 @@ pub fn executive_verdict(results: &[RunMetrics]) -> String {
     let mut out = String::new();
     out.push_str("=== Executive verdict (per configuration) ===\n");
     out.push_str(
-        "Ratios are vs libvips in the SAME snapshot. wall/RSS: <1 beats libvips; \
-         eff: >1 beats libvips.\n\n",
+        "wall (ms) & RSS (MB): lower is better. eff = throughput per peak-RSS MB \
+         (tiles/s/RSS-MB): higher is better.\n\
+         Ratios are vs libvips in the SAME snapshot: wall/RSS <1 beats libvips; eff >1 \
+         beats libvips.\n\n",
     );
     out.push_str(&format!(
         "{:<16} {:<12} {:>12} {:>12} {:>12} {:>12} {:>12}\n",
-        "Config", "Engine", "wall ms", "RSS MB", "eff", "wall/vips", "RSS/vips",
+        "Config", "Engine", "wall ms", "RSS MB", "eff T/s/MB", "wall/vips", "RSS/vips",
     ));
     out.push_str(&format!("{}\n", "-".repeat(92)));
 
@@ -1921,13 +1970,13 @@ pub fn print_savings_summary(results: &[RunMetrics]) {
         for (i, r) in group.iter().enumerate() {
             let label = if i == 0 { &config } else { "" };
             println!(
-                "{:<16} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>10.0} {:>10.1} {:>12.4}",
+                "{:<16} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>10} {:>10.1} {:>12.4}",
                 label,
                 r.engine,
                 r.wall_time_ms(),
                 r.tracked_memory_mb(),
                 r.peak_rss_mb(),
-                r.tiles_per_second(),
+                thousands(r.tiles_per_second().round() as u64),
                 r.tiles_per_second_per_mb(),
                 r.resource_cost_per_tile(),
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1608,6 +1608,13 @@ pub fn comparison_suite(
 /// no metric's unit or better-direction is ever left to a guess (#25). The
 /// primary throughput metric is TILES per second — pyramid tiles
 /// ([`BENCH_TILE_SIZE`] px), never pixels.
+///
+/// Deliberately does NOT assert the warm-median measurement policy: that is a
+/// property of the CALLER's measurement path, not of the data a renderer sees.
+/// [`comparison_table`] appends [`COMPARISON_TABLE_WARM_NOTE`] separately, and
+/// only when every row actually carries multi-iteration stats, so a caller that
+/// renders single-run or cold metrics never emits a false "warm medians" line
+/// (#25 review).
 pub const COMPARISON_TABLE_LEGEND: &str = concat!(
     "Units & direction (T = pyramid tiles, never pixels):\n",
     "  Time (ms) / Tracked MB / RSS MB ............ lower is better\n",
@@ -1615,13 +1622,20 @@ pub const COMPARISON_TABLE_LEGEND: &str = concat!(
     "  T/s/RSS-MB = throughput per peak-RSS MB (memory efficiency)  higher is better\n",
     "  RSS-MB\u{00b7}s/tile = RSS-MB-seconds per tile (resource cost) ..... lower is better\n",
     "Tracked MB is libviprs-internal (0 for libvips); RSS MB is the cross-engine peak.\n",
-    "Figures are warm medians (warm-ups discarded).\n",
 );
+
+/// The warm-median measurement-policy line, appended after
+/// [`COMPARISON_TABLE_LEGEND`] by [`comparison_table`] only when every rendered
+/// row carries multi-iteration stats (the warm harness path). Kept separate from
+/// the units legend so single-run / cold renders don't claim a warm median they
+/// don't have (#25 review).
+pub const COMPARISON_TABLE_WARM_NOTE: &str = "Figures are warm medians (warm-ups discarded).\n";
 
 /// Insert ASCII thousands separators into an integer: `349525` → `"349,525"`.
 /// Keeps large tile / throughput counts legible in the fixed-width text tables
-/// (#25).
-pub fn thousands(n: u64) -> String {
+/// (#25). Named for what it does (format a `u64` with grouping separators)
+/// rather than the ambiguous bare `thousands`.
+pub fn format_thousands(n: u64) -> String {
     let digits = n.to_string();
     let bytes = digits.as_bytes();
     let mut out = String::with_capacity(digits.len() + digits.len() / 3);
@@ -1644,9 +1658,14 @@ pub fn thousands(n: u64) -> String {
 pub fn comparison_table(results: &[RunMetrics]) -> String {
     use std::fmt::Write as _;
     let mut out = String::new();
+    // Tiles / T/s are width-11 (not 8): with thousands separators a 7-figure
+    // count formats to 9 chars ("1,048,576"), which a width-8 field would not
+    // pad but also would not truncate — overflowing and shifting every later
+    // column on that row. Width 11 fits grouped values through the millions
+    // (#25 review).
     let _ = writeln!(
         out,
-        "{:<24} {:<12} {:>10} {:>12} {:>10} {:>8} {:>8} {:>10} {:>12}",
+        "{:<24} {:<12} {:>10} {:>12} {:>10} {:>11} {:>11} {:>10} {:>12}",
         "Label",
         "Engine",
         "Time (ms)",
@@ -1657,23 +1676,31 @@ pub fn comparison_table(results: &[RunMetrics]) -> String {
         "T/s/RSS-MB",
         "RSS-MB\u{00b7}s/tile",
     );
-    let _ = writeln!(out, "{}", "-".repeat(112));
+    let _ = writeln!(out, "{}", "-".repeat(118));
     for r in results {
         let _ = writeln!(
             out,
-            "{:<24} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>8} {:>8} {:>10.1} {:>12.4}",
+            "{:<24} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>11} {:>11} {:>10.1} {:>12.4}",
             r.label,
             r.engine,
             r.wall_time_ms(),
             r.tracked_memory_mb(),
             r.peak_rss_mb(),
-            thousands(r.tiles_produced),
-            thousands(r.tiles_per_second().round() as u64),
+            format_thousands(r.tiles_produced),
+            format_thousands(r.tiles_per_second().round() as u64),
             r.tiles_per_second_per_mb(),
             r.resource_cost_per_tile(),
         );
     }
+    // The unit/direction legend is always valid, so always append it. The
+    // warm-median policy line is only true when every row carries
+    // multi-iteration stats (the warm harness path), so gate it on
+    // all-rows-have-stats — a future single-run/cold caller must not emit a
+    // false "warm medians" claim (#25 review).
     out.push_str(COMPARISON_TABLE_LEGEND);
+    if results.iter().all(|r| r.stats.is_some()) {
+        out.push_str(COMPARISON_TABLE_WARM_NOTE);
+    }
     out
 }
 
@@ -1815,12 +1842,22 @@ pub fn save_history(path: &std::path::Path, history: &[BenchmarkSnapshot]) -> Re
 
 /// Create a `BenchmarkSnapshot` from current run metrics, tagged with the
 /// core version/SHA this harness was built against (`build.rs` stamps).
+///
+/// Takes the [`Provenance`](provenance::Provenance) as a parameter rather than
+/// capturing it here, so the caller controls the sampling instant: the dynamic
+/// load/thermal axes (#25) must be sampled at a well-defined moment (the
+/// `report` binary captures once, before any timed work, and passes that same
+/// value here) instead of re-captured fresh after a CPU-saturating run — which
+/// would record the tail of the benchmark's own load curve and disagree with the
+/// figure the run printed and wrote to `comparison_table.txt` (#25 review).
 pub fn create_snapshot(
+    provenance: provenance::Provenance,
     runs: Vec<RunMetrics>,
     tile_size: u32,
     memory_budget_bytes: u64,
 ) -> BenchmarkSnapshot {
     create_snapshot_for(
+        provenance,
         core_version(),
         core_git_sha(),
         runs,
@@ -1836,8 +1873,10 @@ pub fn create_snapshot(
 /// *separately built* harness per tag, so the version/SHA a snapshot should
 /// carry is the one it resolved from that tag's worktree, not the version this
 /// driver binary was itself compiled against. The environment fingerprint is
-/// still captured live from the current host/toolchain.
+/// captured live from the current host/toolchain by the caller and passed in as
+/// `provenance` (one capture per run — see [`create_snapshot`]).
 pub fn create_snapshot_for(
+    provenance: provenance::Provenance,
     version: &str,
     git_sha: &str,
     runs: Vec<RunMetrics>,
@@ -1846,7 +1885,7 @@ pub fn create_snapshot_for(
 ) -> BenchmarkSnapshot {
     BenchmarkSnapshot {
         schema_version: CURRENT_SCHEMA_VERSION,
-        provenance: provenance::Provenance::capture(),
+        provenance,
         version: version.to_string(),
         git_sha: git_sha.to_string(),
         timestamp: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
@@ -1870,16 +1909,18 @@ pub fn executive_verdict(results: &[RunMetrics]) -> String {
     let mut out = String::new();
     out.push_str("=== Executive verdict (per configuration) ===\n");
     out.push_str(
-        "wall (ms) & RSS (MB): lower is better. eff = throughput per peak-RSS MB \
-         (tiles/s/RSS-MB): higher is better.\n\
+        "T = pyramid tiles (never pixels). wall (ms) & RSS (MB): lower is better. \
+         eff = throughput per peak-RSS MB (T/s/RSS-MB): higher is better.\n\
          Ratios are vs libvips in the SAME snapshot: wall/RSS <1 beats libvips; eff >1 \
          beats libvips.\n\n",
     );
+    // The efficiency column names its full RSS-MB basis ("eff T/s/RSS-MB"), not
+    // the ambiguous "T/s/MB", and is widened to 14 to fit it (#25 review).
     out.push_str(&format!(
-        "{:<16} {:<12} {:>12} {:>12} {:>12} {:>12} {:>12}\n",
-        "Config", "Engine", "wall ms", "RSS MB", "eff T/s/MB", "wall/vips", "RSS/vips",
+        "{:<16} {:<12} {:>12} {:>12} {:>14} {:>12} {:>12}\n",
+        "Config", "Engine", "wall ms", "RSS MB", "eff T/s/RSS-MB", "wall/vips", "RSS/vips",
     ));
-    out.push_str(&format!("{}\n", "-".repeat(92)));
+    out.push_str(&format!("{}\n", "-".repeat(94)));
 
     for group in &groups {
         let cfg = format!(
@@ -1923,7 +1964,7 @@ pub fn executive_verdict(results: &[RunMetrics]) -> String {
             };
             let _ = writeln!(
                 out,
-                "{:<16} {:<12} {:>12.1} {:>12.2} {:>12.1} {:>12} {:>12}",
+                "{:<16} {:<12} {:>12.1} {:>12.2} {:>14.1} {:>12} {:>12}",
                 cfg_col,
                 r.engine,
                 r.wall_time_ms(),
@@ -1950,7 +1991,7 @@ pub fn print_savings_summary(results: &[RunMetrics]) {
 
     println!();
     println!(
-        "{:<16} {:<12} {:>10} {:>12} {:>10} {:>10} {:>10} {:>12}",
+        "{:<16} {:<12} {:>10} {:>12} {:>10} {:>11} {:>10} {:>12}",
         "Config",
         "Engine",
         "Time (ms)",
@@ -1960,7 +2001,7 @@ pub fn print_savings_summary(results: &[RunMetrics]) {
         "T/s/RSS-MB",
         "RSS-MB\u{00b7}s/tile",
     );
-    println!("{}", "-".repeat(98));
+    println!("{}", "-".repeat(99));
 
     for group in &groups {
         let config = format!(
@@ -1970,13 +2011,13 @@ pub fn print_savings_summary(results: &[RunMetrics]) {
         for (i, r) in group.iter().enumerate() {
             let label = if i == 0 { &config } else { "" };
             println!(
-                "{:<16} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>10} {:>10.1} {:>12.4}",
+                "{:<16} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>11} {:>10.1} {:>12.4}",
                 label,
                 r.engine,
                 r.wall_time_ms(),
                 r.tracked_memory_mb(),
                 r.peak_rss_mb(),
-                thousands(r.tiles_per_second().round() as u64),
+                format_thousands(r.tiles_per_second().round() as u64),
                 r.tiles_per_second_per_mb(),
                 r.resource_cost_per_tile(),
             );
@@ -2011,7 +2052,12 @@ mod history_tests {
     #[test]
     fn valid_history_round_trips() {
         let path = scratch_path("valid");
-        let history = vec![create_snapshot(Vec::new(), 256, 1_000_000)];
+        let history = vec![create_snapshot(
+            provenance::Provenance::default(),
+            Vec::new(),
+            256,
+            1_000_000,
+        )];
         save_history(&path, &history).expect("save must succeed");
 
         let loaded = load_history(&path).expect("valid file must parse");
@@ -2076,7 +2122,12 @@ mod history_tests {
 
     #[test]
     fn migrate_snapshot_is_idempotent_on_current_labels() {
-        let mut snap = create_snapshot(Vec::new(), 256, 1_000_000);
+        let mut snap = create_snapshot(
+            provenance::Provenance::default(),
+            Vec::new(),
+            256,
+            1_000_000,
+        );
         let before = snap.schema_version;
         migrate_snapshot(&mut snap);
         assert_eq!(snap.schema_version, before);
@@ -2089,7 +2140,12 @@ mod history_tests {
         // (from build.rs), not this bench harness's own CARGO_PKG_VERSION.
         // A regression to `env!("CARGO_PKG_VERSION")` would fail here
         // whenever core and bench versions differ (the real-world case).
-        let snap = create_snapshot(Vec::new(), 256, 1_000_000);
+        let snap = create_snapshot(
+            provenance::Provenance::default(),
+            Vec::new(),
+            256,
+            1_000_000,
+        );
         assert_eq!(snap.version, core_version());
         assert_eq!(snap.git_sha, core_git_sha());
         assert!(!snap.version.is_empty());

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -89,14 +89,19 @@ pub struct Provenance {
     #[serde(default)]
     pub load_average: Option<LoadAverage>,
     /// Best-effort CPU thermal-throttle indicator sampled at capture time: the
-    /// cumulative core throttle-event count read from Linux sysfs
-    /// (`.../cpu0/thermal_throttle/core_throttle_count`), or `None` when it is
-    /// not cheaply available (macOS, or a container without that sysfs node).
-    /// `Some(0)` means the counter is readable and the CPU has not throttled;
-    /// `Some(n > 0)` flags a box that has thermally throttled — its clocks may
-    /// have been capped during the run. Like [`load_average`](Self::load_average)
-    /// it is a per-run condition, kept out of the fingerprint. Defaults to
-    /// `None` for legacy history (via `#[serde(default)]`).
+    /// maximum cumulative throttle-event count across every core's and the
+    /// package's Linux sysfs counters
+    /// (`.../cpu*/thermal_throttle/{core,package}_throttle_count`), or `None`
+    /// when it is not cheaply available (macOS, or a container without those
+    /// sysfs nodes). Taking the max over all cores/package — rather than reading
+    /// only `cpu0` — means a throttle event on any core is seen, not just core 0.
+    /// `Some(0)` means the counters are readable and nothing has throttled;
+    /// `Some(n > 0)` flags a box that has thermally throttled at some point since
+    /// boot (the counter is cumulative, so a non-zero value is a coarse "runs
+    /// hot" signal, not proof of throttling during this particular run). Like
+    /// [`load_average`](Self::load_average) it is a per-run condition, kept out
+    /// of the fingerprint. Defaults to `None` for legacy history (via
+    /// `#[serde(default)]`).
     #[serde(default)]
     pub thermal_throttle_count: Option<u64>,
 }
@@ -112,11 +117,11 @@ pub struct Provenance {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct LoadAverage {
     /// 1-minute load average.
-    pub one: f64,
+    pub one_min: f64,
     /// 5-minute load average.
-    pub five: f64,
+    pub five_min: f64,
     /// 15-minute load average.
-    pub fifteen: f64,
+    pub fifteen_min: f64,
 }
 
 /// Host machine identity.
@@ -275,25 +280,71 @@ impl Provenance {
         matches!(self.libvips_oracle_match(), OracleMatch::Match)
     }
 
-    /// Whether the host looked contended during the run: the 1-minute load
-    /// average met or exceeded the CPU count, so ready threads were queued
-    /// behind a busy core and the wall-time numbers are inflated by scheduling
-    /// pressure rather than the code under test. `false` when no load average
-    /// was captured or the CPU count is unknown — a missing signal never cries
-    /// wolf. Consumers ([`report`], [`scalability`]) surface a warning on `true`.
+    /// Whether the host looked contended when the load was sampled: the
+    /// 1-minute load average met or exceeded the CPU count, so ready threads
+    /// were already queued behind busy cores. The binaries sample this *before*
+    /// the timed work (see [`report`] / [`scalability`]), so a `true` here means
+    /// the box was under load at the start of the run — an ambient condition
+    /// that inflates wall-time for reasons unrelated to the code under test —
+    /// not a proof that the run itself was contended end to end (the 1-minute
+    /// average is a lagging figure that can miss contention arriving mid-run).
+    /// `false` when no load average was captured or the CPU count is unknown —
+    /// a missing signal never cries wolf. Consumers surface a warning on `true`.
     pub fn host_looked_contended(&self) -> bool {
         match self.load_average {
-            Some(la) if self.host.ncpu > 0 => la.one >= self.host.ncpu as f64,
+            Some(la) if self.host.ncpu > 0 => la.one_min >= self.host.ncpu as f64,
             _ => false,
         }
     }
 
-    /// Whether the CPU has thermally throttled (a non-zero
-    /// [`thermal_throttle_count`](Self::thermal_throttle_count)), so its clocks
-    /// may have been capped during the run. `false` when the indicator is
+    /// Whether the CPU has thermally throttled *at some point since boot* (a
+    /// non-zero [`thermal_throttle_count`](Self::thermal_throttle_count)). The
+    /// underlying sysfs counter is cumulative since boot, so this cannot prove
+    /// throttling *during this run* — only that the box has throttled before,
+    /// possibly hours ago on a now-cool machine. It is a coarse "this host runs
+    /// hot" flag, not a per-run attribution. `false` when the indicator is
     /// unavailable or reads zero.
     pub fn thermally_throttled(&self) -> bool {
         matches!(self.thermal_throttle_count, Some(n) if n > 0)
+    }
+
+    /// The measurement-condition warnings for this run, one string per line, in
+    /// a stable order (contention, then thermal, then oracle mismatch). Empty
+    /// when the run looks clean.
+    ///
+    /// Centralises the wording the `report` and `scalability` binaries print to
+    /// stderr so the two can never drift (they used to hand-roll near-identical
+    /// blocks that had already diverged). Each consumer just does
+    /// `for w in prov.measurement_condition_warnings() { eprintln!("{w}"); }`.
+    pub fn measurement_condition_warnings(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
+        if self.host_looked_contended() {
+            warnings.push(format!(
+                "WARNING: 1-minute host load {} >= {} CPUs when sampled at the start of the \
+                 run — the host was already under load, so these wall-time numbers are inflated \
+                 by scheduling pressure, not the code under test.",
+                self.load_average_line(),
+                self.host.ncpu,
+            ));
+        }
+        if self.thermally_throttled() {
+            warnings.push(
+                "WARNING: CPU thermal-throttle counter is non-zero — this host has thermally \
+                 throttled at some point since boot (the counter is cumulative, so this is not \
+                 proof it throttled during this run); if it did, timing numbers may understate \
+                 true throughput."
+                    .to_string(),
+            );
+        }
+        if let OracleMatch::Mismatch { measured, pinned } = self.libvips_oracle_match() {
+            warnings.push(format!(
+                "WARNING: measured libvips {}.{} != pinned oracle {}.{} — this run measured a \
+                 different libvips than the environment was pinned to build (issue #33); its \
+                 numbers are NOT comparable to a pinned-oracle run.",
+                measured.0, measured.1, pinned.0, pinned.1,
+            ));
+        }
+        warnings
     }
 
     /// One-line host-load summary for banners: `"1.23 / 1.05 / 0.98"` (the
@@ -301,7 +352,10 @@ impl Provenance {
     /// captured on this platform.
     pub fn load_average_line(&self) -> String {
         match self.load_average {
-            Some(la) => format!("{:.2} / {:.2} / {:.2}", la.one, la.five, la.fifteen),
+            Some(la) => format!(
+                "{:.2} / {:.2} / {:.2}",
+                la.one_min, la.five_min, la.fifteen_min
+            ),
             None => "unavailable".to_string(),
         }
     }
@@ -414,10 +468,14 @@ fn load_average() -> Option<LoadAverage> {
         // whitespace-separated fields are the 1/5/15-minute averages.
         let text = std::fs::read_to_string("/proc/loadavg").ok()?;
         let mut parts = text.split_whitespace();
-        let one = parts.next()?.parse::<f64>().ok()?;
-        let five = parts.next()?.parse::<f64>().ok()?;
-        let fifteen = parts.next()?.parse::<f64>().ok()?;
-        Some(LoadAverage { one, five, fifteen })
+        let one_min = parts.next()?.parse::<f64>().ok()?;
+        let five_min = parts.next()?.parse::<f64>().ok()?;
+        let fifteen_min = parts.next()?.parse::<f64>().ok()?;
+        Some(LoadAverage {
+            one_min,
+            five_min,
+            fifteen_min,
+        })
     }
     #[cfg(target_os = "macos")]
     {
@@ -425,11 +483,15 @@ fn load_average() -> Option<LoadAverage> {
         // count written, or -1 on failure. Not exposed by the `libc` crate for
         // glibc Linux, which is why Linux takes the `/proc/loadavg` path above.
         let mut loads = [0f64; 3];
+        // SAFETY: `getloadavg` writes up to `nelem` `f64`s into the buffer and
+        // returns the count written (or -1). `loads` is a 3-element `f64` stack
+        // array and `nelem` is 3, so the pointer is valid for exactly the writes
+        // the call can make; we read a component only when the return count is 3.
         let n = unsafe { libc::getloadavg(loads.as_mut_ptr(), 3) };
         (n == 3).then_some(LoadAverage {
-            one: loads[0],
-            five: loads[1],
-            fifteen: loads[2],
+            one_min: loads[0],
+            five_min: loads[1],
+            fifteen_min: loads[2],
         })
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
@@ -438,21 +500,46 @@ fn load_average() -> Option<LoadAverage> {
     }
 }
 
-/// Best-effort CPU thermal-throttle indicator: the cumulative core
-/// throttle-event count from Linux sysfs, or `None` when not cheaply available.
+/// Best-effort CPU thermal-throttle indicator: the maximum cumulative
+/// throttle-event count across all cores and the package, from Linux sysfs, or
+/// `None` when not cheaply available.
 ///
-/// Reads `/sys/devices/system/cpu/cpu0/thermal_throttle/core_throttle_count`
-/// (a single cheap file read). A non-zero value means core 0 has entered a
-/// thermal-throttle state at least once since boot, so its clocks may have been
-/// capped during the run. `None` on macOS (no equivalent cheap counter — it
-/// would need IOKit/SMC) and on Linux hosts/containers without that sysfs node.
+/// Walks `/sys/devices/system/cpu/cpu<N>/thermal_throttle/` and takes the max
+/// over every readable `core_throttle_count` and `package_throttle_count` (a
+/// handful of cheap file reads). Reading every core — not just `cpu0` — means a
+/// throttle event on any core is caught; a host where `cpu0` stayed cool but
+/// another core throttled would otherwise read a misleading zero. A non-zero
+/// value means *some* core/package entered a thermal-throttle state at least
+/// once since boot. `None` on macOS (no equivalent cheap counter — it would
+/// need IOKit/SMC) and on Linux hosts/containers without those sysfs nodes
+/// (i.e. when not a single counter could be read).
 fn thermal_throttle_count() -> Option<u64> {
     // Exactly one cfg block compiles; each is the function's tail expression.
     #[cfg(target_os = "linux")]
     {
-        std::fs::read_to_string("/sys/devices/system/cpu/cpu0/thermal_throttle/core_throttle_count")
-            .ok()
-            .and_then(|text| text.trim().parse::<u64>().ok())
+        let cpu_root = std::path::Path::new("/sys/devices/system/cpu");
+        let entries = std::fs::read_dir(cpu_root).ok()?;
+        let mut max: Option<u64> = None;
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            // Match `cpu<N>` (a CPU dir), skip `cpufreq`, `cpuidle`, etc.
+            if !(name.starts_with("cpu") && name[3..].chars().all(|c| c.is_ascii_digit()))
+                || name.len() == 3
+            {
+                continue;
+            }
+            let throttle_dir = entry.path().join("thermal_throttle");
+            for counter in ["core_throttle_count", "package_throttle_count"] {
+                if let Some(n) = std::fs::read_to_string(throttle_dir.join(counter))
+                    .ok()
+                    .and_then(|text| text.trim().parse::<u64>().ok())
+                {
+                    max = Some(max.map_or(n, |m| m.max(n)));
+                }
+            }
+        }
+        max
     }
     #[cfg(not(target_os = "linux"))]
     {

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -46,7 +46,12 @@ pub const PINNED_LIBVIPS_SHA256: &str =
     "2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037";
 
 /// Host + toolchain fingerprint for one benchmark snapshot.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+///
+/// `PartialEq` but not `Eq`: the [`load_average`](Provenance::load_average) axis
+/// carries `f64`s (which are only `PartialEq`). Nothing compares a `Provenance`
+/// for `Eq` — grouping is by the string [`fingerprint`](Provenance::fingerprint),
+/// never by whole-struct equality.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Provenance {
     /// libvips runtime version actually measured (e.g. `"8.18.4"`), or
     /// `"unknown"`. Queried from the linked library / `vips` CLI at capture.
@@ -72,6 +77,46 @@ pub struct Provenance {
     /// time. Empty when unknown.
     pub build_flags: String,
     pub host: HostInfo,
+    /// Host load average (1/5/15-minute) sampled at capture time, or `None`
+    /// when it is not cheaply available on the platform. A run measured while
+    /// the box was busy is slower for reasons unrelated to the code under test,
+    /// so recording the load lets a reader discount (or discard) a contended
+    /// measurement rather than mistake it for a regression. Deliberately kept
+    /// *out* of [`Provenance::fingerprint`] — like the pinned-oracle axis, it is
+    /// a per-run *condition*, not part of the environment identity that groups
+    /// comparable runs. Defaults to `None` for history written before this axis
+    /// existed (via `#[serde(default)]`).
+    #[serde(default)]
+    pub load_average: Option<LoadAverage>,
+    /// Best-effort CPU thermal-throttle indicator sampled at capture time: the
+    /// cumulative core throttle-event count read from Linux sysfs
+    /// (`.../cpu0/thermal_throttle/core_throttle_count`), or `None` when it is
+    /// not cheaply available (macOS, or a container without that sysfs node).
+    /// `Some(0)` means the counter is readable and the CPU has not throttled;
+    /// `Some(n > 0)` flags a box that has thermally throttled — its clocks may
+    /// have been capped during the run. Like [`load_average`](Self::load_average)
+    /// it is a per-run condition, kept out of the fingerprint. Defaults to
+    /// `None` for legacy history (via `#[serde(default)]`).
+    #[serde(default)]
+    pub thermal_throttle_count: Option<u64>,
+}
+
+/// Host load average — the 1/5/15-minute run-queue length averages — sampled at
+/// benchmark capture time.
+///
+/// A load average near or above [`HostInfo::ncpu`] means the box was saturated
+/// during the run, so its wall-time numbers are contended and not comparable to
+/// an idle-host measurement. Read from `/proc/loadavg` on Linux and `getloadavg`
+/// on macOS by [`Provenance::capture`]. `PartialEq` (not `Eq`) because the
+/// components are `f64`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct LoadAverage {
+    /// 1-minute load average.
+    pub one: f64,
+    /// 5-minute load average.
+    pub five: f64,
+    /// 15-minute load average.
+    pub fifteen: f64,
 }
 
 /// Host machine identity.
@@ -113,6 +158,8 @@ impl Default for Provenance {
                 os: "unknown".to_string(),
                 in_container: false,
             },
+            load_average: None,
+            thermal_throttle_count: None,
         }
     }
 }
@@ -168,12 +215,20 @@ impl Provenance {
                 os: std::env::consts::OS.to_string(),
                 in_container: detect_container(),
             },
+            load_average: load_average(),
+            thermal_throttle_count: thermal_throttle_count(),
         }
     }
 
     /// A stable, human-readable fingerprint string. Two snapshots with the
     /// same fingerprint were measured in comparable environments; a delta
     /// across differing fingerprints is not apples-to-apples.
+    ///
+    /// The dynamic per-run *conditions* — [`load_average`](Self::load_average)
+    /// and [`thermal_throttle_count`](Self::thermal_throttle_count) — are
+    /// deliberately excluded: a busy or throttled run must still group with an
+    /// idle one on the same box so the contention is visible as an outlier
+    /// rather than splitting the environment into two buckets.
     pub fn fingerprint(&self) -> String {
         format!(
             "vips{}/rustc{}/{}/{}-{}x{}cpu/{}",
@@ -218,6 +273,37 @@ impl Provenance {
     /// ([`OracleMatch::Indeterminate`], e.g. `"unknown"`) side.
     pub fn libvips_matches_pinned(&self) -> bool {
         matches!(self.libvips_oracle_match(), OracleMatch::Match)
+    }
+
+    /// Whether the host looked contended during the run: the 1-minute load
+    /// average met or exceeded the CPU count, so ready threads were queued
+    /// behind a busy core and the wall-time numbers are inflated by scheduling
+    /// pressure rather than the code under test. `false` when no load average
+    /// was captured or the CPU count is unknown — a missing signal never cries
+    /// wolf. Consumers ([`report`], [`scalability`]) surface a warning on `true`.
+    pub fn host_looked_contended(&self) -> bool {
+        match self.load_average {
+            Some(la) if self.host.ncpu > 0 => la.one >= self.host.ncpu as f64,
+            _ => false,
+        }
+    }
+
+    /// Whether the CPU has thermally throttled (a non-zero
+    /// [`thermal_throttle_count`](Self::thermal_throttle_count)), so its clocks
+    /// may have been capped during the run. `false` when the indicator is
+    /// unavailable or reads zero.
+    pub fn thermally_throttled(&self) -> bool {
+        matches!(self.thermal_throttle_count, Some(n) if n > 0)
+    }
+
+    /// One-line host-load summary for banners: `"1.23 / 1.05 / 0.98"` (the
+    /// 1/5/15-minute averages), or `"unavailable"` when no load average was
+    /// captured on this platform.
+    pub fn load_average_line(&self) -> String {
+        match self.load_average {
+            Some(la) => format!("{:.2} / {:.2} / {:.2}", la.one, la.five, la.fifteen),
+            None => "unavailable".to_string(),
+        }
     }
 }
 
@@ -311,6 +397,67 @@ fn cpu_model() -> String {
         }
     }
     "unknown".to_string()
+}
+
+/// Sample the host 1/5/15-minute load average at capture time.
+///
+/// Reads `/proc/loadavg` on Linux (always present in the benchmark container)
+/// and calls `getloadavg` on macOS (the host path); mirrors the same
+/// per-platform split [`cpu_model`] uses. `None` on any other platform or when
+/// the source is unreadable, so a missing sample is honestly absent rather than
+/// a fabricated zero.
+fn load_average() -> Option<LoadAverage> {
+    // Exactly one cfg block compiles; each is the function's tail expression.
+    #[cfg(target_os = "linux")]
+    {
+        // `/proc/loadavg`: "0.52 0.58 0.59 1/1234 5678" — the first three
+        // whitespace-separated fields are the 1/5/15-minute averages.
+        let text = std::fs::read_to_string("/proc/loadavg").ok()?;
+        let mut parts = text.split_whitespace();
+        let one = parts.next()?.parse::<f64>().ok()?;
+        let five = parts.next()?.parse::<f64>().ok()?;
+        let fifteen = parts.next()?.parse::<f64>().ok()?;
+        Some(LoadAverage { one, five, fifteen })
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // `getloadavg` fills up to `nelem` averages (1/5/15-min) and returns the
+        // count written, or -1 on failure. Not exposed by the `libc` crate for
+        // glibc Linux, which is why Linux takes the `/proc/loadavg` path above.
+        let mut loads = [0f64; 3];
+        let n = unsafe { libc::getloadavg(loads.as_mut_ptr(), 3) };
+        (n == 3).then_some(LoadAverage {
+            one: loads[0],
+            five: loads[1],
+            fifteen: loads[2],
+        })
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        None
+    }
+}
+
+/// Best-effort CPU thermal-throttle indicator: the cumulative core
+/// throttle-event count from Linux sysfs, or `None` when not cheaply available.
+///
+/// Reads `/sys/devices/system/cpu/cpu0/thermal_throttle/core_throttle_count`
+/// (a single cheap file read). A non-zero value means core 0 has entered a
+/// thermal-throttle state at least once since boot, so its clocks may have been
+/// capped during the run. `None` on macOS (no equivalent cheap counter — it
+/// would need IOKit/SMC) and on Linux hosts/containers without that sysfs node.
+fn thermal_throttle_count() -> Option<u64> {
+    // Exactly one cfg block compiles; each is the function's tail expression.
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string("/sys/devices/system/cpu/cpu0/thermal_throttle/core_throttle_count")
+            .ok()
+            .and_then(|text| text.trim().parse::<u64>().ok())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
 }
 
 /// Best-effort container detection: cgroup hints on Linux, or the

--- a/src/report.rs
+++ b/src/report.rs
@@ -22,9 +22,9 @@ use std::path::Path;
 use libviprs_bench::harness::{self, Engine};
 use libviprs_bench::provenance::{OracleMatch, Provenance};
 use libviprs_bench::{
-    BENCH_STREAMING_BUDGET, BENCH_TILE_SIZE, DEFAULT_CONCURRENCY, DEFAULT_SIZES, core_git_sha,
-    core_version, create_snapshot, executive_verdict, load_history, print_comparison_table,
-    print_savings_summary, save_history, vips_available,
+    BENCH_STREAMING_BUDGET, BENCH_TILE_SIZE, DEFAULT_CONCURRENCY, DEFAULT_SIZES, comparison_table,
+    core_git_sha, core_version, create_snapshot, executive_verdict, load_history,
+    print_comparison_table, print_savings_summary, save_history, vips_available,
 };
 
 fn main() {
@@ -78,10 +78,30 @@ fn main() {
     println!("    bench harness: {}", env!("CARGO_PKG_VERSION"));
     println!("    environment:  {}", prov.fingerprint());
     println!("    cpu: {} ({} cpus)", prov.host.cpu_model, prov.host.ncpu);
+    println!("    host load (1/5/15m): {}", prov.load_average_line());
     println!(
         "    libvips oracle: measured {} / pinned {}",
         prov.libvips_version, prov.pinned_libvips_version
     );
+    // Contended-host / thermal guards: a run measured while the box was busy or
+    // thermally throttled is slower for reasons unrelated to the code under test,
+    // so its wall-time numbers are not comparable to an idle-host run — say so
+    // loudly on stderr. A missing load/thermal sample never trips these.
+    if prov.host_looked_contended() {
+        eprintln!(
+            "WARNING: 1-minute host load {} >= {} CPUs — this run was measured under \
+             contention; its wall-time numbers are inflated by scheduling pressure, not \
+             the code under test.",
+            prov.load_average_line(),
+            prov.host.ncpu
+        );
+    }
+    if prov.thermally_throttled() {
+        eprintln!(
+            "WARNING: CPU thermal-throttle counter is non-zero — the cores may have been \
+             clock-capped during this run; its timing numbers may understate true throughput."
+        );
+    }
     // Mismatched-oracle guard (#33): if this run measured a different libvips
     // than the environment was pinned to build, its numbers are not comparable
     // to a pinned-oracle run — say so loudly on stderr. Only fires on a genuine
@@ -188,48 +208,32 @@ fn main() {
     println!();
     println!("JSON results written to {}", json_path.display());
 
-    // Write text report
+    // Write text report. The metadata header records what the numbers are and
+    // the conditions they were measured under (environment fingerprint, host
+    // load, cold-vs-warm iteration policy), then the shared `comparison_table`
+    // renders the same table stdout printed — with its units/direction legend —
+    // so the committed artifact is self-describing and can never drift from the
+    // console output.
     let txt_path = report_dir.join("comparison_table.txt");
     let mut txt = String::new();
     txt.push_str(&format!(
         "libviprs engine comparison benchmark (monolithic / streaming / mapreduce)\n\
          measured libviprs core: {} ({})\n\
          bench harness: {}\n\
+         environment: {}\n\
+         host load (1/5/15m): {}\n\
          Tile size: {tile_size}, streaming/mapreduce budget floor: {streaming_budget} bytes \
-         (auto-scaled per width; per-row effective budget in benchmark_results.json)\n\n",
+         (auto-scaled per width; per-row effective budget in benchmark_results.json)\n\
+         Iterations: {iters} timed + {warmup} warm-up per cell (child-isolated); the warm-up \
+         run is discarded, so every figure below is a warm (steady-state) median.\n\n",
         core_version(),
         core_git_sha(),
         env!("CARGO_PKG_VERSION"),
+        prov.fingerprint(),
+        prov.load_average_line(),
     ));
 
-    txt.push_str(&format!(
-        "{:<24} {:<12} {:>10} {:>12} {:>10} {:>8} {:>8} {:>10} {:>12}\n",
-        "Label",
-        "Engine",
-        "Time (ms)",
-        "Tracked MB",
-        "RSS MB",
-        "Tiles",
-        "T/s",
-        "T/s/RSS-MB",
-        "RSS-MB\u{00b7}s/tile"
-    ));
-    txt.push_str(&format!("{}\n", "-".repeat(112)));
-
-    for r in &results {
-        txt.push_str(&format!(
-            "{:<24} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>8} {:>8.0} {:>10.1} {:>12.4}\n",
-            r.label,
-            r.engine,
-            r.wall_time_ms(),
-            r.tracked_memory_mb(),
-            r.peak_rss_mb(),
-            r.tiles_produced,
-            r.tiles_per_second(),
-            r.tiles_per_second_per_mb(),
-            r.resource_cost_per_tile(),
-        ));
-    }
+    txt.push_str(&comparison_table(&results));
     fs::write(&txt_path, &txt).unwrap();
     println!("Text report written to {}", txt_path.display());
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -20,7 +20,7 @@ use std::fs;
 use std::path::Path;
 
 use libviprs_bench::harness::{self, Engine};
-use libviprs_bench::provenance::{OracleMatch, Provenance};
+use libviprs_bench::provenance::Provenance;
 use libviprs_bench::{
     BENCH_STREAMING_BUDGET, BENCH_TILE_SIZE, DEFAULT_CONCURRENCY, DEFAULT_SIZES, comparison_table,
     core_git_sha, core_version, create_snapshot, executive_verdict, load_history,
@@ -83,37 +83,15 @@ fn main() {
         "    libvips oracle: measured {} / pinned {}",
         prov.libvips_version, prov.pinned_libvips_version
     );
-    // Contended-host / thermal guards: a run measured while the box was busy or
-    // thermally throttled is slower for reasons unrelated to the code under test,
-    // so its wall-time numbers are not comparable to an idle-host run — say so
-    // loudly on stderr. A missing load/thermal sample never trips these.
-    if prov.host_looked_contended() {
-        eprintln!(
-            "WARNING: 1-minute host load {} >= {} CPUs — this run was measured under \
-             contention; its wall-time numbers are inflated by scheduling pressure, not \
-             the code under test.",
-            prov.load_average_line(),
-            prov.host.ncpu
-        );
-    }
-    if prov.thermally_throttled() {
-        eprintln!(
-            "WARNING: CPU thermal-throttle counter is non-zero — the cores may have been \
-             clock-capped during this run; its timing numbers may understate true throughput."
-        );
-    }
-    // Mismatched-oracle guard (#33): if this run measured a different libvips
-    // than the environment was pinned to build, its numbers are not comparable
-    // to a pinned-oracle run — say so loudly on stderr. Only fires on a genuine
-    // parsed mismatch, never on a host run that simply has no libvips.
-    if let OracleMatch::Mismatch { measured, pinned } = prov.libvips_oracle_match() {
-        eprintln!(
-            "WARNING: measured libvips {}.{} != pinned oracle {}.{} — this run \
-             measured a different libvips than the environment was pinned to \
-             build (issue #33); its numbers are NOT comparable to a \
-             pinned-oracle run.",
-            measured.0, measured.1, pinned.0, pinned.1
-        );
+    // Measurement-condition guards: a run measured while the box was busy or
+    // thermally throttled, or against a different libvips than the environment
+    // was pinned to build (#33), is not comparable to a clean pinned-oracle run
+    // — say so loudly on stderr. The wording lives on `Provenance` so the
+    // `report` and `scalability` binaries share one source and can never drift
+    // (issue #25 review). A missing load/thermal sample, or a host run with no
+    // libvips, never trips these.
+    for warning in prov.measurement_condition_warnings() {
+        eprintln!("{warning}");
     }
     println!();
     println!(
@@ -224,8 +202,7 @@ fn main() {
          host load (1/5/15m): {}\n\
          Tile size: {tile_size}, streaming/mapreduce budget floor: {streaming_budget} bytes \
          (auto-scaled per width; per-row effective budget in benchmark_results.json)\n\
-         Iterations: {iters} timed + {warmup} warm-up per cell (child-isolated); the warm-up \
-         run is discarded, so every figure below is a warm (steady-state) median.\n\n",
+         Iterations: {iters} timed + {warmup} warm-up per cell (child-isolated).\n\n",
         core_version(),
         core_git_sha(),
         env!("CARGO_PKG_VERSION"),
@@ -260,7 +237,14 @@ fn main() {
     println!();
     match load_history(&history_path) {
         Ok(mut history) => {
-            let snapshot = create_snapshot(results.clone(), tile_size, streaming_budget);
+            // Persist the SAME provenance captured at the top of the run (before
+            // any timed work), so the load/thermal the history file records is
+            // the ambient pre-run condition its own doc promises — and equals the
+            // value this run printed and wrote to comparison_table.txt. Capturing
+            // fresh here would instead record the tail of the benchmark's OWN load
+            // curve, disagreeing with the printed/txt figure (issue #25 review).
+            let snapshot =
+                create_snapshot(prov.clone(), results.clone(), tile_size, streaming_budget);
             history.push(snapshot);
             match save_history(&history_path, &history) {
                 Ok(()) => {

--- a/src/scalability.rs
+++ b/src/scalability.rs
@@ -5,13 +5,15 @@
 //! fixture is not committed, so the workload is a stand-in sized to that
 //! page's 1.42:1 aspect, NOT a rasterized blueprint. Runs all four engines
 //! (libvips, monolithic, streaming, MapReduce) at each size and at matched
-//! thread budgets (1 and num_cpus), producing SVG line charts — one set per
-//! thread budget — showing how wall time, peak RSS, and efficiency scale
-//! with image area.
+//! thread budgets (1 and num_cpus), measuring how wall time, peak RSS, and
+//! efficiency scale with image area.
 //!
 //! Run: cargo run --release --bin scalability
 //!
-//! Output: report/scalability_*.svg + report/scalability_results.json
+//! Output: report/scalability_results.json. This binary emits JSON only; the
+//! `scalability_*.svg` line charts render from that JSON via
+//! `tools/charts/render.mjs` (run-bench.sh invokes it after this writes the
+//! JSON) — the plotters dependency is gone (issue #42).
 
 // The chart plumbing threads fixed-arity metric tuples and borrowed series
 // slices through a few local closures; naming each as a `type` would add
@@ -31,7 +33,7 @@ use libviprs::{
 };
 use libviprs_bench::provenance::{OracleMatch, Provenance};
 use libviprs_bench::{
-    bench_libvips, gradient_raster, streaming_budget_for, vips_available, write_temp_png,
+    bench_libvips, gradient_raster, streaming_budget_for, thousands, vips_available, write_temp_png,
 };
 
 /// Peak RSS of the current process in bytes. Mirrors the RSS basis the
@@ -525,6 +527,7 @@ fn main() {
     // numbers are not comparable to a pinned-oracle run — warn loudly. Only
     // fires on a genuine parsed mismatch, never on a host run without libvips.
     let prov = Provenance::capture();
+    println!("Host load (1/5/15m): {}", prov.load_average_line());
     if let OracleMatch::Mismatch { measured, pinned } = prov.libvips_oracle_match() {
         eprintln!(
             "WARNING: measured libvips {}.{} != pinned oracle {}.{} — this \
@@ -532,6 +535,22 @@ fn main() {
              was pinned to build (issue #33); its numbers are NOT comparable \
              to a pinned-oracle run.",
             measured.0, measured.1, pinned.0, pinned.1
+        );
+    }
+    // A contended or thermally throttled host inflates these wall-time numbers
+    // for reasons unrelated to the engines under test — flag it loudly.
+    if prov.host_looked_contended() {
+        eprintln!(
+            "WARNING: 1-minute host load {} >= {} CPUs — this scalability run was measured \
+             under contention; its wall-time numbers are inflated by scheduling pressure.",
+            prov.load_average_line(),
+            prov.host.ncpu
+        );
+    }
+    if prov.thermally_throttled() {
+        eprintln!(
+            "WARNING: CPU thermal-throttle counter is non-zero — the cores may have been \
+             clock-capped during this run."
         );
     }
     println!();
@@ -743,11 +762,20 @@ fn main() {
             p.wall_time_ms,
             p.tracked_memory_mb,
             p.peak_rss_mb,
-            p.tiles_produced,
+            thousands(p.tiles_produced),
             p.tiles_per_second_per_mb,
             p.resource_cost,
         );
     }
+    // Units & direction (T = pyramid tiles, never pixels):
+    println!(
+        "  Time (ms) / Tracked MB / RSS MB: lower is better. \
+         T/s/RSS-MB = tiles/s per peak-RSS MB (memory efficiency): higher is better."
+    );
+    println!(
+        "  RSS-MB\u{00b7}s/tile = RSS-MB-seconds per tile (resource cost): lower is better. \
+         Tracked MB is libviprs-internal (0 for libvips); RSS MB is the cross-engine peak."
+    );
 
     // --- Memory bottleneck analysis ---
     println!();
@@ -878,11 +906,11 @@ fn main() {
     }
 
     println!();
-    println!(
-        "Charts written to {}/scalability_*.svg",
-        report_dir.display()
-    );
     println!("JSON written to {}", json_path.display());
+    println!(
+        "Scalability charts (scalability_*.svg) render from that JSON via \
+         tools/charts/render.mjs (run-bench.sh invokes it; this binary emits JSON only)."
+    );
 }
 
 #[cfg(test)]

--- a/src/scalability.rs
+++ b/src/scalability.rs
@@ -31,9 +31,10 @@ use libviprs::{
     EngineBuilder, EngineConfig, EngineKind, FsSink, Layout, PyramidPlanner, Raster,
     RasterStripSource, TileFormat,
 };
-use libviprs_bench::provenance::{OracleMatch, Provenance};
+use libviprs_bench::provenance::Provenance;
 use libviprs_bench::{
-    bench_libvips, gradient_raster, streaming_budget_for, thousands, vips_available, write_temp_png,
+    bench_libvips, format_thousands, gradient_raster, streaming_budget_for, vips_available,
+    write_temp_png,
 };
 
 /// Peak RSS of the current process in bytes. Mirrors the RSS basis the
@@ -522,36 +523,17 @@ fn main() {
     } else {
         println!("libvips CLI: not found, skipping");
     }
-    // Mismatched-oracle guard (#33) on the default container CMD: if this run
-    // measured a different libvips than the container was pinned to build, its
-    // numbers are not comparable to a pinned-oracle run — warn loudly. Only
-    // fires on a genuine parsed mismatch, never on a host run without libvips.
+    // Measurement-condition guards (contended host / thermal / mismatched
+    // oracle #33): a run measured under load, while thermally throttled, or
+    // against a different libvips than the container was pinned to build is not
+    // comparable to a clean pinned-oracle run — flag it loudly. The wording
+    // lives on `Provenance` so this binary and `report` share one source and can
+    // never drift (issue #25 review). Only genuine signals trip these; a host
+    // run without libvips does not.
     let prov = Provenance::capture();
     println!("Host load (1/5/15m): {}", prov.load_average_line());
-    if let OracleMatch::Mismatch { measured, pinned } = prov.libvips_oracle_match() {
-        eprintln!(
-            "WARNING: measured libvips {}.{} != pinned oracle {}.{} — this \
-             scalability run measured a different libvips than the container \
-             was pinned to build (issue #33); its numbers are NOT comparable \
-             to a pinned-oracle run.",
-            measured.0, measured.1, pinned.0, pinned.1
-        );
-    }
-    // A contended or thermally throttled host inflates these wall-time numbers
-    // for reasons unrelated to the engines under test — flag it loudly.
-    if prov.host_looked_contended() {
-        eprintln!(
-            "WARNING: 1-minute host load {} >= {} CPUs — this scalability run was measured \
-             under contention; its wall-time numbers are inflated by scheduling pressure.",
-            prov.load_average_line(),
-            prov.host.ncpu
-        );
-    }
-    if prov.thermally_throttled() {
-        eprintln!(
-            "WARNING: CPU thermal-throttle counter is non-zero — the cores may have been \
-             clock-capped during this run."
-        );
+    for warning in prov.measurement_condition_warnings() {
+        eprintln!("{warning}");
     }
     println!();
 
@@ -743,7 +725,7 @@ fn main() {
     // Print summary table
     println!();
     println!(
-        "{:<14} {:<12} {:>10} {:>12} {:>10} {:>8} {:>12} {:>14}",
+        "{:<14} {:<12} {:>10} {:>12} {:>10} {:>11} {:>12} {:>14}",
         "Size",
         "Engine",
         "Time (ms)",
@@ -753,24 +735,25 @@ fn main() {
         "T/s/RSS-MB",
         "RSS-MB\u{00b7}s/tile",
     );
-    println!("{}", "-".repeat(92));
+    println!("{}", "-".repeat(97));
     for p in &all_points {
         println!(
-            "{:<14} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>8} {:>12.1} {:>14.4}",
+            "{:<14} {:<12} {:>10.1} {:>12.2} {:>10.2} {:>11} {:>12.1} {:>14.4}",
             format!("{}x{}", p.width, p.height),
             p.engine,
             p.wall_time_ms,
             p.tracked_memory_mb,
             p.peak_rss_mb,
-            thousands(p.tiles_produced),
+            format_thousands(p.tiles_produced),
             p.tiles_per_second_per_mb,
             p.resource_cost,
         );
     }
-    // Units & direction (T = pyramid tiles, never pixels):
+    // Units & direction (T = pyramid tiles, never pixels) — phrased to match the
+    // shared `COMPARISON_TABLE_LEGEND` so the two human-facing tables agree.
     println!(
         "  Time (ms) / Tracked MB / RSS MB: lower is better. \
-         T/s/RSS-MB = tiles/s per peak-RSS MB (memory efficiency): higher is better."
+         T/s/RSS-MB = throughput per peak-RSS MB (memory efficiency): higher is better."
     );
     println!(
         "  RSS-MB\u{00b7}s/tile = RSS-MB-seconds per tile (resource cost): lower is better. \

--- a/src/version_matrix.rs
+++ b/src/version_matrix.rs
@@ -485,8 +485,19 @@ pub fn append_version_snapshot(
     memory_budget_bytes: u64,
 ) -> Result<usize, MatrixError> {
     let mut history = crate::load_history(history_path).map_err(MatrixError::History)?;
-    let snapshot =
-        crate::create_snapshot_for(version, git_sha, runs, tile_size, memory_budget_bytes);
+    // Capture provenance live in this driver process — the host/toolchain is the
+    // same for every tag — and inject it, matching the one-capture-per-run model
+    // the `report` binary uses now that provenance carries dynamic load/thermal
+    // axes (#25 review).
+    let provenance = crate::provenance::Provenance::capture();
+    let snapshot = crate::create_snapshot_for(
+        provenance,
+        version,
+        git_sha,
+        runs,
+        tile_size,
+        memory_budget_bytes,
+    );
     history.push(snapshot);
     // `save_history` is atomic (temp file + rename) and fallible: a write fault
     // is surfaced as a per-version `History` skip so the sweep continues and the

--- a/tests/chart_shape_drift.rs
+++ b/tests/chart_shape_drift.rs
@@ -214,9 +214,22 @@ fn golden_run_metrics_matches_the_serializer_shape() {
 
 #[test]
 fn golden_snapshot_matches_the_serializer_shape() {
-    // `create_snapshot` stamps a live-captured Provenance, so this also pins the
-    // Provenance + HostInfo + nested-runs shape the history golden must carry.
-    let snapshot: BenchmarkSnapshot = create_snapshot(vec![sample_run_metrics()], 256, 4_000_000);
+    // This pins the Provenance + HostInfo + nested-runs shape the history golden
+    // must carry. Inject a provenance whose dynamic axes are populated
+    // (`load_average = Some`) so the serialized SHAPE is deterministic regardless
+    // of host: the golden carries a populated `load_average` OBJECT, and a host
+    // where `getloadavg` is unavailable would otherwise serialize `null` and
+    // drift the shape. (#25 made provenance an explicit parameter, which is what
+    // lets the test pin this instead of depending on the runner's live load.)
+    let mut prov = libviprs_bench::provenance::Provenance::capture();
+    prov.load_average = Some(libviprs_bench::provenance::LoadAverage {
+        one_min: 1.5,
+        five_min: 1.2,
+        fifteen_min: 1.0,
+    });
+    prov.thermal_throttle_count = Some(0);
+    let snapshot: BenchmarkSnapshot =
+        create_snapshot(prov, vec![sample_run_metrics()], 256, 4_000_000);
     let serialized = serde_json::to_value(&snapshot).unwrap();
     let golden = read_golden("golden_history.json");
     let first = golden

--- a/tests/flamegraph_weighting.rs
+++ b/tests/flamegraph_weighting.rs
@@ -1,0 +1,100 @@
+//! Flame-graph time-weighting guard (#25).
+//!
+//! A flame graph's frame WIDTH must be proportional to the TIME spent, not to a
+//! flat per-event sample count. The event flame graph derives per-tile time from
+//! the `TileCompleted` timestamps the in-tree engines stamp, so a tile that took
+//! twice as long draws twice as wide. This pins that contract:
+//!
+//!   * [`tile_weight_micros`] turns an inter-tile wall-clock gap into a
+//!     microsecond sample weight, flooring at 1 so inferno never drops a frame;
+//!   * [`events_to_folded_stacks`] weights each tile frame by that gap and emits
+//!     ONLY time-weighted tile frames — never the old count-as-weight marker
+//!     lines (`level_N_start {tile_count}`) that injected a tile COUNT onto the
+//!     time axis.
+
+use std::time::{Duration, SystemTime};
+
+use libviprs::{EngineEvent, TileCoord};
+use libviprs_bench::flame::{events_to_folded_stacks, tile_weight_micros};
+
+/// A tile whose gap since the previous tile is 30 ms weighs exactly 30 000 µs —
+/// three times a 10 ms tile. The weight is TIME, in microseconds.
+#[test]
+fn tile_weight_is_the_inter_tile_gap_in_micros() {
+    let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+    assert_eq!(
+        tile_weight_micros(Some(base), Some(base + Duration::from_millis(30))),
+        30_000
+    );
+    assert_eq!(
+        tile_weight_micros(Some(base), Some(base + Duration::from_millis(10))),
+        10_000
+    );
+}
+
+/// The floor: a first tile with no predecessor, a missing timestamp, a backwards
+/// clock (skew), or a zero gap all weigh 1 µs — never 0 (inferno drops a
+/// zero-count frame) and never an underflowed huge value.
+#[test]
+fn tile_weight_floors_at_one() {
+    let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+    assert_eq!(tile_weight_micros(None, Some(base)), 1, "no predecessor floors at 1");
+    assert_eq!(tile_weight_micros(Some(base), None), 1, "missing timestamp floors at 1");
+    assert_eq!(
+        tile_weight_micros(Some(base + Duration::from_millis(5)), Some(base)),
+        1,
+        "a backwards clock floors at 1, never underflows"
+    );
+    assert_eq!(tile_weight_micros(Some(base), Some(base)), 1, "a zero gap still keeps the frame");
+}
+
+/// The folded stacks weight tile frames by TIME: three tiles at 0 / 10 / 30 ms
+/// yield per-tile weights 1, 10 000, 20 000 (a 1:2 ratio between the measured
+/// tiles), NOT three equal counts — and carry no count-as-weight marker frame
+/// (the tile_count / tiles_produced = 3 must appear nowhere as a weight).
+#[test]
+fn folded_stacks_are_time_weighted_not_count_weighted() {
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+    let tile = |col: u32, at: SystemTime| EngineEvent::TileCompleted {
+        coord: TileCoord::new(0, col, 0),
+        worker_id: None,
+        timestamp: Some(at),
+    };
+    let events = vec![
+        EngineEvent::LevelStarted { level: 0, width: 512, height: 512, tile_count: 3 },
+        tile(0, t0),                              // first tile: floored to 1
+        tile(1, t0 + Duration::from_millis(10)),  // +10 ms
+        tile(2, t0 + Duration::from_millis(30)),  // +20 ms
+        EngineEvent::LevelCompleted { level: 0, tiles_produced: 3 },
+    ];
+
+    let stacks = events_to_folded_stacks(&events, "monolithic");
+
+    // Each folded line is "stack weight"; split the trailing integer weight off.
+    let parsed: Vec<(String, u64)> = stacks
+        .iter()
+        .map(|s| {
+            let (stack, w) = s.rsplit_once(' ').expect("a folded line carries a weight");
+            (stack.to_string(), w.parse::<u64>().expect("the weight is an integer"))
+        })
+        .collect();
+
+    // Only time-weighted tile frames are emitted — nested under engine;level_0.
+    for (stack, _) in &parsed {
+        assert!(
+            stack.contains(";level_0;tile_"),
+            "every frame is a time-weighted tile frame, got `{stack}`"
+        );
+    }
+
+    let weights: Vec<u64> = parsed.iter().map(|(_, w)| *w).collect();
+    assert_eq!(
+        weights,
+        vec![1, 10_000, 20_000],
+        "tile weights track the inter-tile time gaps, not a flat count"
+    );
+    assert!(
+        !weights.contains(&3),
+        "a tile COUNT (3) must never leak in as a sample weight"
+    );
+}

--- a/tests/flamegraph_weighting.rs
+++ b/tests/flamegraph_weighting.rs
@@ -121,3 +121,60 @@ fn folded_stacks_are_time_weighted_not_count_weighted() {
         "a tile COUNT (3) must never leak in as a sample weight"
     );
 }
+
+/// Pins the strip-batch / concurrent-emission limitation the module docs call
+/// out (and the streaming / MapReduce SVG titles warn about): when a strip
+/// renders and then emits its tiles back-to-back, the first tile of the strip
+/// absorbs the whole strip's wall time and the rest drain in near-zero gaps. So
+/// per-tile widths are emission CADENCE, not per-tile compute time — the
+/// boundary tile dwarfs its neighbours that did comparable work. What stays
+/// honest is the AGGREGATE: because each weight is the gap since the previous
+/// tile, the weights tile the timeline and their sum equals the wall-clock span
+/// (which is why the level/root width is a true wall-time measure even here).
+#[test]
+fn batch_burst_loads_the_boundary_tile_yet_the_aggregate_is_the_wall_span() {
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+    let tile = |col: u32, at: SystemTime| EngineEvent::TileCompleted {
+        coord: TileCoord::new(0, col, 0),
+        worker_id: None,
+        timestamp: Some(at),
+    };
+    // A strip that took 40 ms to render, then four tiles draining effectively
+    // instantly (their emit timestamps cluster at the 40 ms boundary) — the
+    // pattern `emit_strip_tiles`/`emit_strip_tiles_parallel` produces.
+    let first = t0; // first tile ever: no predecessor -> floored to 1 µs
+    let boundary = t0 + Duration::from_millis(40); // absorbs the strip render
+    let drain1 = boundary + Duration::from_micros(5);
+    let drain2 = drain1 + Duration::from_micros(5);
+    let events = vec![
+        tile(0, first),
+        tile(1, boundary),
+        tile(2, drain1),
+        tile(3, drain2),
+    ];
+
+    let weights: Vec<u64> = events_to_folded_stacks(&events, "mapreduce")
+        .iter()
+        .map(|s| s.rsplit_once(' ').unwrap().1.parse::<u64>().unwrap())
+        .collect();
+
+    assert_eq!(
+        weights,
+        vec![1, 40_000, 5, 5],
+        "the strip-boundary tile absorbs the 40 ms render; the drained tiles get slivers"
+    );
+    // The artifact: the boundary tile looks thousands of times heavier than the
+    // neighbours that did comparable per-tile work — so a per-tile reading lies.
+    assert!(
+        weights[1] > weights[2] * 1_000,
+        "per-tile widths are emission cadence, not per-tile compute time"
+    );
+    // The honest part: the weights sum to the wall-clock span (plus the single
+    // floored sliver for the very first tile, which has no predecessor gap).
+    let span_micros = drain2.duration_since(first).unwrap().as_micros() as u64;
+    assert_eq!(
+        weights.iter().sum::<u64>(),
+        span_micros + 1,
+        "the aggregate width equals the wall-clock span — the level/root measure stays true"
+    );
+}

--- a/tests/flamegraph_weighting.rs
+++ b/tests/flamegraph_weighting.rs
@@ -38,14 +38,26 @@ fn tile_weight_is_the_inter_tile_gap_in_micros() {
 #[test]
 fn tile_weight_floors_at_one() {
     let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
-    assert_eq!(tile_weight_micros(None, Some(base)), 1, "no predecessor floors at 1");
-    assert_eq!(tile_weight_micros(Some(base), None), 1, "missing timestamp floors at 1");
+    assert_eq!(
+        tile_weight_micros(None, Some(base)),
+        1,
+        "no predecessor floors at 1"
+    );
+    assert_eq!(
+        tile_weight_micros(Some(base), None),
+        1,
+        "missing timestamp floors at 1"
+    );
     assert_eq!(
         tile_weight_micros(Some(base + Duration::from_millis(5)), Some(base)),
         1,
         "a backwards clock floors at 1, never underflows"
     );
-    assert_eq!(tile_weight_micros(Some(base), Some(base)), 1, "a zero gap still keeps the frame");
+    assert_eq!(
+        tile_weight_micros(Some(base), Some(base)),
+        1,
+        "a zero gap still keeps the frame"
+    );
 }
 
 /// The folded stacks weight tile frames by TIME: three tiles at 0 / 10 / 30 ms
@@ -61,11 +73,19 @@ fn folded_stacks_are_time_weighted_not_count_weighted() {
         timestamp: Some(at),
     };
     let events = vec![
-        EngineEvent::LevelStarted { level: 0, width: 512, height: 512, tile_count: 3 },
-        tile(0, t0),                              // first tile: floored to 1
-        tile(1, t0 + Duration::from_millis(10)),  // +10 ms
-        tile(2, t0 + Duration::from_millis(30)),  // +20 ms
-        EngineEvent::LevelCompleted { level: 0, tiles_produced: 3 },
+        EngineEvent::LevelStarted {
+            level: 0,
+            width: 512,
+            height: 512,
+            tile_count: 3,
+        },
+        tile(0, t0),                             // first tile: floored to 1
+        tile(1, t0 + Duration::from_millis(10)), // +10 ms
+        tile(2, t0 + Duration::from_millis(30)), // +20 ms
+        EngineEvent::LevelCompleted {
+            level: 0,
+            tiles_produced: 3,
+        },
     ];
 
     let stacks = events_to_folded_stacks(&events, "monolithic");
@@ -75,7 +95,10 @@ fn folded_stacks_are_time_weighted_not_count_weighted() {
         .iter()
         .map(|s| {
             let (stack, w) = s.rsplit_once(' ').expect("a folded line carries a weight");
-            (stack.to_string(), w.parse::<u64>().expect("the weight is an integer"))
+            (
+                stack.to_string(),
+                w.parse::<u64>().expect("the weight is an integer"),
+            )
         })
         .collect();
 

--- a/tests/host_load_provenance.rs
+++ b/tests/host_load_provenance.rs
@@ -75,8 +75,12 @@ fn legacy_provenance_without_load_or_thermal_deserializes() {
         }
     }"#;
 
-    let prov: Provenance = serde_json::from_str(legacy).expect("legacy provenance must still parse");
-    assert_eq!(prov.load_average, None, "absent load average defaults to None");
+    let prov: Provenance =
+        serde_json::from_str(legacy).expect("legacy provenance must still parse");
+    assert_eq!(
+        prov.load_average, None,
+        "absent load average defaults to None"
+    );
     assert_eq!(
         prov.thermal_throttle_count, None,
         "absent thermal indicator defaults to None"

--- a/tests/host_load_provenance.rs
+++ b/tests/host_load_provenance.rs
@@ -22,7 +22,7 @@ fn capture_records_a_host_load_average() {
     let la = prov
         .load_average
         .expect("load average must be recorded on linux/macos");
-    for v in [la.one, la.five, la.fifteen] {
+    for v in [la.one_min, la.five_min, la.fifteen_min] {
         assert!(
             v.is_finite() && v >= 0.0,
             "each load component is finite and non-negative, got {v}"
@@ -35,9 +35,9 @@ fn capture_records_a_host_load_average() {
 fn load_and_thermal_round_trip() {
     let mut prov = Provenance::capture();
     prov.load_average = Some(LoadAverage {
-        one: 3.5,
-        five: 2.0,
-        fifteen: 1.25,
+        one_min: 3.5,
+        five_min: 2.0,
+        fifteen_min: 1.25,
     });
     prov.thermal_throttle_count = Some(7);
 
@@ -47,9 +47,9 @@ fn load_and_thermal_round_trip() {
     assert_eq!(
         back.load_average,
         Some(LoadAverage {
-            one: 3.5,
-            five: 2.0,
-            fifteen: 1.25
+            one_min: 3.5,
+            five_min: 2.0,
+            fifteen_min: 1.25
         })
     );
     assert_eq!(back.thermal_throttle_count, Some(7));
@@ -90,6 +90,55 @@ fn legacy_provenance_without_load_or_thermal_deserializes() {
     assert_eq!(prov.host.ncpu, 10);
 }
 
+/// The centralised measurement-condition warnings (#25 review): one source of
+/// wording for the `report` and `scalability` binaries so their stderr guards
+/// can never drift again. A clean provenance warns about nothing; a contended,
+/// thermally-throttled, mispinned one emits exactly the three lines, in order.
+#[test]
+fn measurement_condition_warnings_are_centralised() {
+    // Clean: idle (no load average), no thermal counter, oracle indeterminate
+    // (both versions "unknown") — nothing to warn about.
+    let clean = Provenance::default();
+    assert!(
+        clean.measurement_condition_warnings().is_empty(),
+        "a clean run warns about nothing"
+    );
+
+    // Contended + throttled + mispinned — all three guards trip, in order.
+    let mut dirty = Provenance::default();
+    dirty.host.ncpu = 4;
+    dirty.load_average = Some(LoadAverage {
+        one_min: 8.0,
+        five_min: 6.0,
+        fifteen_min: 5.0,
+    });
+    dirty.thermal_throttle_count = Some(3);
+    dirty.libvips_version = "8.16.0".to_string();
+    dirty.pinned_libvips_version = "8.18.4".to_string();
+
+    let warnings = dirty.measurement_condition_warnings();
+    assert_eq!(
+        warnings.len(),
+        3,
+        "contention + thermal + oracle mismatch, got: {warnings:?}"
+    );
+    assert!(
+        warnings[0].contains("host load") && warnings[0].contains(">= 4 CPUs"),
+        "first line is the contention guard: {}",
+        warnings[0]
+    );
+    assert!(
+        warnings[1].contains("thermal-throttle"),
+        "second line is the thermal guard: {}",
+        warnings[1]
+    );
+    assert!(
+        warnings[2].contains("8.16") && warnings[2].contains("8.18") && warnings[2].contains("#33"),
+        "third line is the mismatched-oracle guard: {}",
+        warnings[2]
+    );
+}
+
 /// Load average and thermal state are per-run measurement *conditions*, not part
 /// of the environment identity: two runs on the same box under different loads
 /// must still group together, so the fingerprint must not vary with them —
@@ -100,15 +149,15 @@ fn load_and_thermal_are_not_in_the_fingerprint() {
     let mut idle = Provenance::capture();
     let mut loaded = idle.clone();
     idle.load_average = Some(LoadAverage {
-        one: 0.1,
-        five: 0.1,
-        fifteen: 0.1,
+        one_min: 0.1,
+        five_min: 0.1,
+        fifteen_min: 0.1,
     });
     idle.thermal_throttle_count = Some(0);
     loaded.load_average = Some(LoadAverage {
-        one: 40.0,
-        five: 39.0,
-        fifteen: 38.0,
+        one_min: 40.0,
+        five_min: 39.0,
+        fifteen_min: 38.0,
     });
     loaded.thermal_throttle_count = Some(999);
     assert_eq!(

--- a/tests/host_load_provenance.rs
+++ b/tests/host_load_provenance.rs
@@ -1,0 +1,115 @@
+//! Host load-average + thermal-throttle provenance guard (#25).
+//!
+//! A wall-time number measured while the host was under load — or while the CPU
+//! was thermally throttled — is slower for reasons that have nothing to do with
+//! the code under test. [`Provenance`] therefore samples the host load average
+//! (and, where cheaply available, a thermal-throttle indicator) at capture time,
+//! so a loaded or throttled measurement run is flagged in the snapshot rather
+//! than silently polluting a cross-version delta.
+//!
+//! Both axes are additive with a serde default, so a `benchmark_history.json`
+//! written before #25 (no such fields) still deserializes.
+
+use libviprs_bench::provenance::{LoadAverage, Provenance};
+
+/// `capture()` records the host load average on the platforms the benchmarks
+/// run on (the Linux container and the macOS host): three finite, non-negative
+/// numbers read from `/proc/loadavg` (Linux) or `getloadavg` (macOS).
+#[test]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn capture_records_a_host_load_average() {
+    let prov = Provenance::capture();
+    let la = prov
+        .load_average
+        .expect("load average must be recorded on linux/macos");
+    for v in [la.one, la.five, la.fifteen] {
+        assert!(
+            v.is_finite() && v >= 0.0,
+            "each load component is finite and non-negative, got {v}"
+        );
+    }
+}
+
+/// A snapshot's load-average + thermal fields serde round-trip unchanged.
+#[test]
+fn load_and_thermal_round_trip() {
+    let mut prov = Provenance::capture();
+    prov.load_average = Some(LoadAverage {
+        one: 3.5,
+        five: 2.0,
+        fifteen: 1.25,
+    });
+    prov.thermal_throttle_count = Some(7);
+
+    let json = serde_json::to_string(&prov).unwrap();
+    let back: Provenance = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(
+        back.load_average,
+        Some(LoadAverage {
+            one: 3.5,
+            five: 2.0,
+            fifteen: 1.25
+        })
+    );
+    assert_eq!(back.thermal_throttle_count, Some(7));
+}
+
+/// Legacy provenance written before these axes existed still deserializes: the
+/// new fields serde-default to `None`, so an old history file keeps loading
+/// (the same forward-compatibility the pinned-oracle axis already enjoys).
+#[test]
+fn legacy_provenance_without_load_or_thermal_deserializes() {
+    let legacy = r#"{
+        "libvips_version": "8.18.4",
+        "pinned_libvips_version": "8.18.4",
+        "rustc_version": "rustc 1.89.0",
+        "build_profile": "release",
+        "build_flags": "-C target-cpu=native",
+        "host": {
+            "cpu_model": "Apple M1 Max",
+            "ncpu": 10,
+            "arch": "aarch64",
+            "os": "macos",
+            "in_container": false
+        }
+    }"#;
+
+    let prov: Provenance = serde_json::from_str(legacy).expect("legacy provenance must still parse");
+    assert_eq!(prov.load_average, None, "absent load average defaults to None");
+    assert_eq!(
+        prov.thermal_throttle_count, None,
+        "absent thermal indicator defaults to None"
+    );
+    // The pre-existing axes still populate.
+    assert_eq!(prov.libvips_version, "8.18.4");
+    assert_eq!(prov.host.ncpu, 10);
+}
+
+/// Load average and thermal state are per-run measurement *conditions*, not part
+/// of the environment identity: two runs on the same box under different loads
+/// must still group together, so the fingerprint must not vary with them —
+/// mirroring how the pinned-oracle axis is deliberately kept out of the
+/// fingerprint.
+#[test]
+fn load_and_thermal_are_not_in_the_fingerprint() {
+    let mut idle = Provenance::capture();
+    let mut loaded = idle.clone();
+    idle.load_average = Some(LoadAverage {
+        one: 0.1,
+        five: 0.1,
+        fifteen: 0.1,
+    });
+    idle.thermal_throttle_count = Some(0);
+    loaded.load_average = Some(LoadAverage {
+        one: 40.0,
+        five: 39.0,
+        fifteen: 38.0,
+    });
+    loaded.thermal_throttle_count = Some(999);
+    assert_eq!(
+        idle.fingerprint(),
+        loaded.fingerprint(),
+        "an idle and a loaded run on the same box share one environment fingerprint"
+    );
+}

--- a/tests/metric_labels.rs
+++ b/tests/metric_labels.rs
@@ -1,0 +1,113 @@
+//! Metric-labelling guard (#25).
+//!
+//! Every figure the report prints must state its UNIT and its DIRECTION (higher-
+//! or lower-is-better) so a reader never has to guess. In particular the primary
+//! throughput metric is TILES per second (never pixels per second), and the
+//! ratio metrics (efficiency, resource cost) must say which way is better. This
+//! pins the human-facing comparison table and the executive verdict.
+
+use std::time::Duration;
+
+use libviprs_bench::{RunMetrics, RunStats, comparison_table, executive_verdict};
+
+/// One config, two engines. `tiles_produced` is large enough to exercise the
+/// thousands separator in the table.
+fn sample() -> Vec<RunMetrics> {
+    vec![
+        run("2048x2048_c0_monolithic", "monolithic", 1_250.0, 349_525, 512.0),
+        run("2048x2048_c0_vips", "libvips", 900.0, 349_525, 300.0),
+    ]
+}
+
+fn run(label: &str, engine: &str, wall_ms: f64, tiles: u64, rss_mb: f64) -> RunMetrics {
+    RunMetrics {
+        label: label.to_string(),
+        width: 2048,
+        height: 2048,
+        engine: engine.to_string(),
+        measurement_path: String::new(),
+        wall_time: Duration::from_secs_f64(wall_ms / 1000.0),
+        tracked_memory_bytes: 16_777_216,
+        peak_rss_bytes: (rss_mb * 1024.0 * 1024.0) as u64,
+        stats: Some(RunStats {
+            n: 7,
+            wall_ms_median: wall_ms,
+            wall_ms_min: wall_ms - 3.0,
+            wall_ms_iqr: 3.0,
+            wall_ms_ci95: 1.5,
+            rss_mb_median: rss_mb,
+            rss_mb_min: rss_mb - 2.0,
+            rss_mb_iqr: 2.0,
+            rss_mb_ci95: 1.0,
+        }),
+        per_level_tiles: vec![256, 64, 16, 4, 1],
+        equivalence_psnr_db: Some(48.0),
+        tiles_produced: tiles,
+        levels_processed: 5,
+        tiles_skipped: 0,
+        strips: 0,
+        batches: 0,
+        inflight_strips: 0,
+        concurrency: 0,
+        memory_budget_bytes: 0,
+    }
+}
+
+/// The comparison table names the throughput unit as tiles-per-second and spells
+/// out every metric's direction, so neither the unit (tiles vs pixels) nor the
+/// direction (higher/lower is better) is ever left to a guess.
+#[test]
+fn comparison_table_states_units_and_direction() {
+    let table = comparison_table(&sample());
+
+    // The throughput column + the tiles-not-pixels disambiguation.
+    assert!(table.contains("T/s"), "throughput column present");
+    assert!(
+        table.to_lowercase().contains("tiles per second")
+            || table.to_lowercase().contains("tiles/second")
+            || table.to_lowercase().contains("tiles written per second"),
+        "the throughput unit is spelled out as tiles per second"
+    );
+    assert!(
+        !table.to_lowercase().contains("pixels per second")
+            && !table.to_lowercase().contains("pixels/s"),
+        "throughput is tiles/s, never pixels/s"
+    );
+
+    // Direction for both a higher-is-better and a lower-is-better metric.
+    assert!(
+        table.contains("higher is better"),
+        "throughput / efficiency direction stated"
+    );
+    assert!(
+        table.contains("lower is better"),
+        "wall time / resource cost direction stated"
+    );
+
+    // The resource-cost and efficiency units appear.
+    assert!(table.contains("RSS-MB\u{00b7}s/tile"), "resource-cost unit present");
+    assert!(table.contains("T/s/RSS-MB"), "efficiency unit present");
+}
+
+/// Large tile counts read with thousands separators for legibility.
+#[test]
+fn comparison_table_groups_thousands() {
+    let table = comparison_table(&sample());
+    assert!(
+        table.contains("349,525"),
+        "tile counts carry thousands separators, got:\n{table}"
+    );
+}
+
+/// The executive verdict states the direction of every axis it ranks (wall / RSS
+/// lower-is-better, efficiency higher-is-better) and names the efficiency unit.
+#[test]
+fn executive_verdict_states_units_and_direction() {
+    let verdict = executive_verdict(&sample());
+    assert!(verdict.contains("lower is better"), "wall/RSS direction stated");
+    assert!(verdict.contains("higher is better"), "efficiency direction stated");
+    assert!(
+        verdict.to_lowercase().contains("tiles/s"),
+        "the efficiency unit is named (tiles/s per RSS-MB)"
+    );
+}

--- a/tests/metric_labels.rs
+++ b/tests/metric_labels.rs
@@ -122,7 +122,11 @@ fn executive_verdict_states_units_and_direction() {
         "efficiency direction stated"
     );
     assert!(
-        verdict.to_lowercase().contains("tiles/s"),
-        "the efficiency unit is named (tiles/s per RSS-MB)"
+        verdict.contains("T/s/RSS-MB"),
+        "the efficiency unit names its full RSS-MB basis (T/s/RSS-MB), not the ambiguous T/s/MB"
+    );
+    assert!(
+        verdict.contains("T = pyramid tiles"),
+        "the T = tiles key is restated so the T/s shorthand is unambiguous"
     );
 }

--- a/tests/metric_labels.rs
+++ b/tests/metric_labels.rs
@@ -14,7 +14,13 @@ use libviprs_bench::{RunMetrics, RunStats, comparison_table, executive_verdict};
 /// thousands separator in the table.
 fn sample() -> Vec<RunMetrics> {
     vec![
-        run("2048x2048_c0_monolithic", "monolithic", 1_250.0, 349_525, 512.0),
+        run(
+            "2048x2048_c0_monolithic",
+            "monolithic",
+            1_250.0,
+            349_525,
+            512.0,
+        ),
         run("2048x2048_c0_vips", "libvips", 900.0, 349_525, 300.0),
     ]
 }
@@ -85,7 +91,10 @@ fn comparison_table_states_units_and_direction() {
     );
 
     // The resource-cost and efficiency units appear.
-    assert!(table.contains("RSS-MB\u{00b7}s/tile"), "resource-cost unit present");
+    assert!(
+        table.contains("RSS-MB\u{00b7}s/tile"),
+        "resource-cost unit present"
+    );
     assert!(table.contains("T/s/RSS-MB"), "efficiency unit present");
 }
 
@@ -104,8 +113,14 @@ fn comparison_table_groups_thousands() {
 #[test]
 fn executive_verdict_states_units_and_direction() {
     let verdict = executive_verdict(&sample());
-    assert!(verdict.contains("lower is better"), "wall/RSS direction stated");
-    assert!(verdict.contains("higher is better"), "efficiency direction stated");
+    assert!(
+        verdict.contains("lower is better"),
+        "wall/RSS direction stated"
+    );
+    assert!(
+        verdict.contains("higher is better"),
+        "efficiency direction stated"
+    );
     assert!(
         verdict.to_lowercase().contains("tiles/s"),
         "the efficiency unit is named (tiles/s per RSS-MB)"

--- a/tests/version_matrix.rs
+++ b/tests/version_matrix.rs
@@ -339,6 +339,7 @@ fn ordered_version_keys_sorts_by_semver_and_timestamp_not_lexically() {
 /// test (bypassing `create_snapshot` so the timestamp is deterministic).
 fn snap_with(version: &str, git_sha: &str, timestamp: &str) -> BenchmarkSnapshot {
     let mut snap = libviprs_bench::create_snapshot_for(
+        libviprs_bench::provenance::Provenance::default(),
         version,
         git_sha,
         vec![synthetic_run("monolithic", 1)],

--- a/tools/charts/fixtures/golden_history.json
+++ b/tools/charts/fixtures/golden_history.json
@@ -15,9 +15,9 @@
         "in_container": false
       },
       "load_average": {
-        "one": 1.5,
-        "five": 1.2,
-        "fifteen": 1.0
+        "one_min": 1.5,
+        "five_min": 1.2,
+        "fifteen_min": 1.0
       },
       "thermal_throttle_count": null
     },
@@ -181,9 +181,9 @@
         "in_container": false
       },
       "load_average": {
-        "one": 1.5,
-        "five": 1.2,
-        "fifteen": 1.0
+        "one_min": 1.5,
+        "five_min": 1.2,
+        "fifteen_min": 1.0
       },
       "thermal_throttle_count": null
     },

--- a/tools/charts/fixtures/golden_history.json
+++ b/tools/charts/fixtures/golden_history.json
@@ -13,7 +13,13 @@
         "arch": "aarch64",
         "os": "macos",
         "in_container": false
-      }
+      },
+      "load_average": {
+        "one": 1.5,
+        "five": 1.2,
+        "fifteen": 1.0
+      },
+      "thermal_throttle_count": null
     },
     "version": "0.4.0",
     "git_sha": "aa11bb2",
@@ -173,7 +179,13 @@
         "arch": "aarch64",
         "os": "macos",
         "in_container": false
-      }
+      },
+      "load_average": {
+        "one": 1.5,
+        "five": 1.2,
+        "fifteen": 1.0
+      },
+      "thermal_throttle_count": null
     },
     "version": "0.4.1",
     "git_sha": "cc33dd4",

--- a/tools/charts/labels.test.mjs
+++ b/tools/charts/labels.test.mjs
@@ -1,0 +1,86 @@
+// Metric-labelling spec for the render.mjs chart titles (#25).
+//
+// The grouped-bar comparison charts already name each metric's unit + direction
+// in their titles (chart.mjs wrappers). The SCALABILITY and HISTORY charts must
+// do the same: a reader must never have to guess whether a line going up is good
+// or bad, nor what "throughput" is measured in. This pins the titles the two
+// render.mjs builders emit.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildScalabilityCharts, buildHistoryCharts } from './render.mjs';
+
+const SCAL_POINTS = [
+  {
+    engine: 'monolithic',
+    megapixels: 1,
+    concurrency: 1,
+    wall_time_ms: 10,
+    peak_rss_mb: 5,
+    tiles_produced: 100,
+    tiles_per_second: 100,
+    tiles_per_second_per_mb: 20,
+    resource_cost: 0.01,
+  },
+  {
+    engine: 'monolithic',
+    megapixels: 4,
+    concurrency: 1,
+    wall_time_ms: 40,
+    peak_rss_mb: 8,
+    tiles_produced: 400,
+    tiles_per_second: 200,
+    tiles_per_second_per_mb: 25,
+    resource_cost: 0.02,
+  },
+];
+
+// Two snapshots for one config → a history trend exists.
+function snapshot(version, wallSecs, rssBytes) {
+  return {
+    version,
+    runs: [
+      {
+        engine: 'monolithic',
+        width: 1024,
+        height: 1024,
+        concurrency: 0,
+        wall_time: { secs: wallSecs, nanos: 0 },
+        peak_rss_bytes: rssBytes,
+        tiles_produced: 85,
+      },
+    ],
+  };
+}
+
+test('scalability chart titles state their unit and direction', () => {
+  const byName = Object.fromEntries(
+    buildScalabilityCharts(SCAL_POINTS).map((c) => [c.filename, c.svg]),
+  );
+
+  // Wall time / peak RSS / resource cost: lower is better.
+  assert.match(byName['scalability_wall_time_c1.svg'], /lower is better/, 'wall time direction');
+  assert.match(byName['scalability_peak_memory_c1.svg'], /lower is better/, 'peak RSS direction');
+  assert.match(byName['scalability_resource_cost_c1.svg'], /lower is better/, 'resource cost direction');
+
+  // Throughput / efficiency: higher is better, and throughput names its tiles/s unit.
+  const tput = byName['scalability_throughput_c1.svg'];
+  assert.match(tput, /Tiles\/s/, 'throughput names its unit (tiles/s)');
+  assert.match(tput, /higher is better/, 'throughput direction');
+  assert.match(byName['scalability_efficiency_c1.svg'], /higher is better/, 'efficiency direction');
+
+  // Throughput is tiles/s, never pixels/s.
+  assert.ok(!tput.toLowerCase().includes('pixels/s'), 'throughput is tiles/s, not pixels/s');
+});
+
+test('history chart titles state their direction', () => {
+  const charts = buildHistoryCharts([
+    snapshot('0.3.0', 1, 100 * 1024 * 1024),
+    snapshot('0.3.1', 2, 120 * 1024 * 1024),
+  ]);
+  assert.ok(charts.length >= 2, 'a wall-time and a peak-RSS trend are produced');
+  for (const { filename, svg } of charts) {
+    assert.match(svg, /lower is better/, `${filename} states its direction`);
+  }
+});

--- a/tools/charts/render.mjs
+++ b/tools/charts/render.mjs
@@ -160,11 +160,14 @@ function threadCap(conc) {
 export function buildHistoryCharts(snapshots) {
   const out = [];
   if (!Array.isArray(snapshots) || snapshots.length < 2) return out;
+  // Both trended metrics are lower-is-better; the title states it so a downward
+  // trend line reads unambiguously as an improvement.
   const metrics = [
-    { suffix: 'time', label: 'Wall Time', unitSuffix: 'ms', valueOf: (r) => durationMs(r.wall_time) },
+    { suffix: 'time', label: 'Wall Time', direction: 'lower is better', unitSuffix: 'ms', valueOf: (r) => durationMs(r.wall_time) },
     {
       suffix: 'memory',
       label: 'Peak RSS',
+      direction: 'lower is better',
       unitSuffix: 'MB',
       // `peak_rss_bytes` is `#[serde(default)] = 0`, where 0 means UNKNOWN
       // (legacy history predating the field), not a real zero-memory run.
@@ -179,7 +182,7 @@ export function buildHistoryCharts(snapshots) {
       const runs = new Set(points.map((p) => p.runIndex));
       if (runs.size < 2) continue; // need >= 2 snapshots for a trend
       const svg = renderHistoryTrend(points, {
-        title: `${metric.label} History — ${config.width}x${config.height} c${config.concurrency}`,
+        title: `${metric.label} History — ${config.width}x${config.height} c${config.concurrency} (${metric.direction})`,
         unitSuffix: metric.unitSuffix,
       });
       out.push({ filename: `chart_history_${config.key}_${metric.suffix}.svg`, svg });
@@ -247,15 +250,19 @@ export function buildComparisonCharts(results) {
 export function buildScalabilityCharts(points, { linear = false, xMin = null } = {}) {
   const out = [];
   if (!Array.isArray(points) || points.length === 0) return out;
+  // Each title names the metric's unit and its better-direction (higher/lower),
+  // matching the grouped-bar comparison charts, so a reader never has to guess
+  // whether a rising line is good or bad. The primary throughput metric is
+  // TILES/s (pyramid tiles), never pixels/s.
   const metrics = [
-    { suffix: 'wall_time', title: 'Wall Time Scalability', yLabel: 'Time (ms)', unitSuffix: 'ms', valueOf: (p) => p.wall_time_ms },
+    { suffix: 'wall_time', title: 'Wall Time Scalability (lower is better)', yLabel: 'Time (ms)', unitSuffix: 'ms', valueOf: (p) => p.wall_time_ms },
     // `peak_rss_mb ?? peak_memory_mb` mirrors the Rust
     // `#[serde(alias = "peak_memory_mb")]` so pre-#153 scalability JSON that
     // still uses the old field name is read, not silently dropped.
-    { suffix: 'peak_memory', title: 'Peak RSS Scalability', yLabel: 'Peak RSS (MB)', unitSuffix: 'MB', valueOf: (p) => p.peak_rss_mb ?? p.peak_memory_mb },
-    { suffix: 'throughput', title: 'Throughput Scalability', yLabel: 'Tiles/s', unitSuffix: '', valueOf: (p) => p.tiles_per_second },
-    { suffix: 'efficiency', title: 'Memory Efficiency — Tiles/s per RSS-MB', yLabel: 'Tiles/s/RSS-MB', unitSuffix: '', valueOf: (p) => p.tiles_per_second_per_mb },
-    { suffix: 'resource_cost', title: 'Resource Cost — RSS-MB·s per Tile', yLabel: 'RSS-MB·s/tile', unitSuffix: '', valueOf: (p) => p.resource_cost },
+    { suffix: 'peak_memory', title: 'Peak RSS Scalability (lower is better)', yLabel: 'Peak RSS (MB)', unitSuffix: 'MB', valueOf: (p) => p.peak_rss_mb ?? p.peak_memory_mb },
+    { suffix: 'throughput', title: 'Throughput Scalability — Tiles/s (higher is better)', yLabel: 'Tiles/s', unitSuffix: '', valueOf: (p) => p.tiles_per_second },
+    { suffix: 'efficiency', title: 'Memory Efficiency — Tiles/s per RSS-MB (higher is better)', yLabel: 'Tiles/s/RSS-MB', unitSuffix: '', valueOf: (p) => p.tiles_per_second_per_mb },
+    { suffix: 'resource_cost', title: 'Resource Cost — RSS-MB·s per Tile (lower is better)', yLabel: 'RSS-MB·s/tile', unitSuffix: '', valueOf: (p) => p.resource_cost },
   ];
   const zoomed = Number.isFinite(xMin);
   const suffix = zoomed ? '_zoom' : '';

--- a/tools/charts/render.test.mjs
+++ b/tools/charts/render.test.mjs
@@ -100,9 +100,13 @@ test('the history time chart reflects the fixture gap (streaming broken)', () =>
 
 test('missing input files are skipped, not fatal', () => {
   const outDir = freshOut();
+  // Every input path is overridden to a missing file, including resultsPath —
+  // otherwise it defaults to the real report dir and a stray benchmark_results.json
+  // (e.g. left by a local `report` run) would make this non-hermetic.
   const written = renderAll({
     historyPath: join(FIX, 'does-not-exist.json'),
     scalabilityPath: join(FIX, 'nope.json'),
+    resultsPath: join(FIX, 'also-missing.json'),
     outDir,
   });
   assert.deepEqual(written, [], 'nothing written when no JSON is present');


### PR DESCRIPTION
Resolves **#25** — the final residual sweep of the lower-severity benchmark-review items. (1) Metric labeling: units + higher/lower-is-better on every column (report tables, comparison_table.txt, cross_version, JS charts); primary throughput disambiguated (T = pyramid tiles, never pixels). (2) Table formatting: thousands separators + widened columns. (3) Cold/warm: warm-median disclosure + iters/warmup policy in the committed artifact. (4) Thermal/load: `Provenance.load_average` + `thermal_throttle_count` (serde-default, excluded from fingerprint, surfaced as contention/throttle warnings). (5) Flamegraph: corrected to true time-weighting (µs by inter-tile gap; count-as-weight markers removed; per-tile claim scoped to the serial engine). (6) Docs: fixed stale README/module/run-bench.sh references (pdf_engine_bench→pdfium_strip_source_bench, plotters/crop/replot).

TDD RED→GREEN. 4-expert review applied. **Convergence mode: no new issues filed.** Local gate + 68 JS tests green.

Closes #25