### PR TITLE
Migrate CI to self-hosted Gitea Actions

### DIFF
--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    branches: ['**']
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,6 +13,14 @@ jobs:
     name: Check & Lint feature cells
     runs-on: ubuntu-latest
     steps:
+      - name: Report pending to GitHub
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GH_STATUS_TOKEN }}
+        run: |
+          curl -sf -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -d '{"state":"pending","context":"gitea/ci","target_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_number }}","description":"Gitea Actions run started"}' || true
       # libviprs-bench depends on `libviprs = { path = "../libviprs" }`, so
       # the core repo must sit alongside as a sibling directory.
       - uses: actions/checkout@v4
@@ -76,3 +83,24 @@ jobs:
       - name: Test (libvips feature)
         working-directory: libviprs-bench
         run: cargo test --lib --tests --doc --features libvips
+
+  report:
+    name: Report status to GitHub
+    needs: [check, test]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Report result to GitHub
+        env:
+          GH_TOKEN: ${{ secrets.GH_STATUS_TOKEN }}
+        run: |
+          if [ "${{ needs.check.result }}" = "success" ] && [ "${{ needs.test.result }}" = "success" ]; then
+            STATE="success"
+            DESC="Gitea Actions run passed"
+          else
+            STATE="failure"
+            DESC="Gitea Actions run failed"
+          fi
+          curl -sf -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -d "{\"state\":\"$STATE\",\"context\":\"gitea/ci\",\"target_url\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_number }}\",\"description\":\"$DESC\"}" || true

--- a/.github/workflows/gitea-ci-relay.yml
+++ b/.github/workflows/gitea-ci-relay.yml
@@ -1,0 +1,14 @@
+name: gitea-ci-relay
+on:
+  push:
+jobs:
+  nudge-mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Trigger Gitea mirror sync
+        env:
+          GITEA_SYNC_TOKEN: ${{ secrets.GITEA_SYNC_TOKEN }}
+        run: |
+          curl -sf -X POST -H "Authorization: token $GITEA_SYNC_TOKEN" \
+            "https://git.opsite.ca/api/v1/repos/${{ github.repository }}/mirror-sync"


### PR DESCRIPTION
Moves all CI checks off GitHub Actions onto the self-hosted Gitea Actions runner.

## What changed
- **New `.gitea/workflows/ci.yml`** — the `check` and `test` jobs (same steps as before), now triggered on `push` to any branch (`branches: ['**']`) and manual `workflow_dispatch`. A `report` job posts `gitea/ci` commit statuses back to GitHub (pending at start, success/failure on completion).
- **New `.github/workflows/gitea-ci-relay.yml`** — the only remaining GitHub Actions workflow; nudges the Gitea pull mirror to sync on every push.
- **Removed `.github/workflows/ci.yml`** — no real CI runs on GitHub anymore.

## Notes
- No publish/release workflow exists in this repo, so nothing was flagged there.
- CI results appear as the `gitea/ci` status context on commits/PRs.