### PR TITLE
ci: point human-facing action-run links at the public forge URL

### DIFF
--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     name: Check & Lint feature cells
     runs-on: ubuntu-latest
     steps:
+      # target_url is human-clicked from GitHub, so it uses the PUBLIC forge URL (vars.GIT_PUBLIC_URL); github.server_url is the runner's internal gitea:3000, for API and git calls only.
       - name: Report pending to GitHub
         if: always()
         env:
@@ -20,7 +21,7 @@ jobs:
         run: |
           curl -sf -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }}" \
-            -d '{"state":"pending","context":"gitea/ci","target_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_number }}","description":"Gitea Actions run started"}' || true
+            -d '{"state":"pending","context":"gitea/ci","target_url":"${{ vars.GIT_PUBLIC_URL }}/${{ github.repository }}/actions/runs/${{ github.run_number }}","description":"Gitea Actions run started"}' || true
       # libviprs-bench depends on `libviprs = { path = "../libviprs" }`, so
       # the core repo must sit alongside as a sibling directory.
       - uses: actions/checkout@v4
@@ -90,6 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
+      # target_url is human-clicked from GitHub, so it uses the PUBLIC forge URL (vars.GIT_PUBLIC_URL); github.server_url is the runner's internal gitea:3000, for API and git calls only.
       - name: Report result to GitHub
         env:
           GH_TOKEN: ${{ secrets.GH_STATUS_TOKEN }}
@@ -103,4 +105,4 @@ jobs:
           fi
           curl -sf -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }}" \
-            -d "{\"state\":\"$STATE\",\"context\":\"gitea/ci\",\"target_url\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_number }}\",\"description\":\"$DESC\"}" || true
+            -d "{\"state\":\"$STATE\",\"context\":\"gitea/ci\",\"target_url\":\"${{ vars.GIT_PUBLIC_URL }}/${{ github.repository }}/actions/runs/${{ github.run_number }}\",\"description\":\"$DESC\"}" || true


### PR DESCRIPTION
## Problem

The `gitea/ci` commit status this repo posts onto GitHub carried a `target_url`
of `http://gitea:3000/<org>/<repo>/actions/runs/<n>`. That host only exists on
the `gitea-net` Docker network, so the link is dead for whoever clicks it from
the pull request.

## Cause

One value was serving two different needs.

The act_runner registers against the internal `http://gitea:3000`, so inside a
job `${{ github.server_url }}` resolves to that address. **That is correct and
is not changed here.** Runner traffic stays on the Docker network, never leaves
the host and comes back through Caddy, and the runner keeps no inbound HTTP
surface.

It is simply not a URL a human can follow. Gitea's own links are already
correct, because `ROOT_URL` is `https://git.opsite.ca/`. I confirmed that
against the live API: `GET /repos/iasbuilt/webapp/actions/tasks` returns
`"url": "https://git.opsite.ca/iasbuilt/webapp/actions/runs/314"`. The bad link
was never emitted by Gitea, it was built here and posted to the GitHub
commit-status API.

## Change

Human-facing link sites now read a separate, explicitly public variable:

| Expression | Value | Use |
|---|---|---|
| `${{ github.server_url }}` | `http://gitea:3000` | API and git calls from inside a job |
| `${{ vars.GIT_PUBLIC_URL }}` | `https://git.opsite.ca` | anything a human clicks |

Only `target_url` sites changed. Every other `github.server_url` use stays
internal, and each switched site carries a comment saying which of the two it
is, so the next person does not helpfully unify them again.

## The variable

`GIT_PUBLIC_URL` is an **org-scoped Gitea Actions variable**, already live on
both `iasbuilt` and `libviprs`, so there is no per-repo setup and nothing to
configure before merging.

It is not called `GITEA_PUBLIC_URL` because Gitea reserves the `GITEA_` and
`GITHUB_` prefixes for Actions variable names and rejects them with HTTP 400
`invalid secret name`. Verified against this instance (1.24.7):

```
POST /api/v1/orgs/iasbuilt/actions/variables/GITEA_PUBLIC_URL -> 400 invalid secret name
POST /api/v1/orgs/iasbuilt/actions/variables/GIT_PUBLIC_URL   -> 204
```

Provisioning is codified in the IaC repo in `iasbuilt/IaC` PR #103, so a rebuild
recreates it.

## Not changed

- The runner registration / `gitea_act_runner_instance_url`.
- `GITEA__server__ROOT_URL`, which is already correct.

## Verification

YAML parses. The only remaining `github.server_url` mentions in the changed
files are inside the explanatory comments. Not waiting on CI, the shared runner
is backed up.
