### PR TITLE
Run CI nightly so core drift shows up while it is one day wide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ name: CI
 on:
   push:
     branches: ['**']
+  # Both jobs clone libviprs at whatever `main` is, so the thing under test
+  # moves without a commit here to notice. On push-only triggers the last run
+  # of any kind was 2026-08-25 while 585 core commits landed behind it, so the
+  # next person to push inherits every one of those breakages at once (#57).
+  # A nightly reports the drift while it is still one day wide. 05:31 UTC
+  # keeps it off the top of the hour and away from libviprs-cli's nightly,
+  # which runs at 06:11.
+  schedule:
+    - cron: '31 5 * * *'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Closes #57

## What I changed

`.github/workflows/ci.yml`: a `schedule:` trigger at `31 5 * * *`, alongside the existing `push` and `workflow_dispatch`.

## Why

Both jobs clone the core at whatever `main` is, so what this crate compiles against changes without a commit here. With push-only triggers, nothing runs until somebody pushes, and this repo is not pushed often: the last CI run of any kind was 2026-08-25.

```
$ gh run list -R libviprs/libviprs-bench --limit 3 --json createdAt,conclusion,workflowName
2026-08-25T15:54:05Z  success  CI
2026-08-25T15:38:10Z  success  CI
2026-08-25T15:32:35Z  failure  CI

$ git -C libviprs log --oneline --since=2026-08-25 origin/main | wc -l
     585
```

585 core commits behind an unpinned path dependency, with the next push here carrying all of them at once. A nightly turns that into one day of drift with a one-day suspect list.

## Times

05:31 UTC here, 06:11 UTC in libviprs-cli (libviprs-cli#50), so the two nightlies do not start together, and neither sits on the top of an hour where GitHub's scheduler is most congested.

## What this does not do

It does not pin the counterpart. Building against core `main` is this crate's arrangement, and the nightly is what makes it honest rather than merely quiet. A real pin here would be a bigger change and its own issue.

Worth knowing: GitHub suspends scheduled workflows in a repository with no commit activity for 60 days, and mails the repo admins when it does.

## Proof

The workflow parses and keeps both jobs:

```
$ python3 -c "import yaml;d=yaml.safe_load(open('.github/workflows/ci.yml'));print(d[True]);print(sorted(d['jobs']))"
{'push': {'branches': ['**']}, 'schedule': [{'cron': '31 5 * * *'}], 'workflow_dispatch': None}
['check', 'test']
```

(`d[True]` because YAML 1.1 reads the key `on` as the boolean true.)

I also ran the default cell of the `check` job locally, against the core at `694fd4b2` laid out as a sibling:

```
$ cargo check --lib --bins --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.34s
EXIT=0
```

The `libvips`, `pdfium` and `polars` cells I did not run: they want a `libvips-dev` install and a native PDFium this machine does not have set up for them, so I am not claiming anything about those. The run this push produces is what will say.
